### PR TITLE
Feature/test faucet

### DIFF
--- a/src/contexts/Order/Order.tsx
+++ b/src/contexts/Order/Order.tsx
@@ -11,8 +11,14 @@ import { useWeb3React } from "@web3-react/core";
 
 import UniswapPairs from "./uniswap_pairs.json";
 import { buy, sell } from "../../lib/uniswap";
-import { mint, exercise, redeem, close, create } from "../../lib/primitive";
-import { mintTestToken } from "../../lib/utils";
+import {
+    mint,
+    exercise,
+    redeem,
+    close,
+    create,
+    mintTestToken,
+} from "../../lib/primitive";
 require("dotenv").config();
 
 const NotifyKey = process.env.REACT_APP_NOTIFY_KEY;
@@ -119,9 +125,13 @@ const Order: React.FC = (props) => {
         notifyInstance.hash(tx.hash);
     };
 
-    const handleMintTestToken = async (provider, tokenAddress, quantity) => {
+    const handleMintTestTokens = async (
+        provider,
+        optionAddress: string,
+        quantity: any
+    ) => {
         let signer = await provider.getSigner();
-        let tx = await mintTestToken(signer, tokenAddress, quantity);
+        let tx = await mintTestToken(signer, optionAddress, quantity);
         notifyInstance.hash(tx.hash);
     };
 
@@ -152,6 +162,7 @@ const Order: React.FC = (props) => {
                 closeOptions: handleCloseOptions,
                 loadPendingTx: loadPendingTx,
                 createOption: handleCreateOption,
+                mintTestTokens: handleMintTestTokens,
             }}
         >
             {props.children}

--- a/src/contexts/Order/Order.tsx
+++ b/src/contexts/Order/Order.tsx
@@ -12,6 +12,7 @@ import { useWeb3React } from "@web3-react/core";
 import UniswapPairs from "./uniswap_pairs.json";
 import { buy, sell } from "../../lib/uniswap";
 import { mint, exercise, redeem, close, create } from "../../lib/primitive";
+import { mintTestToken } from "../../lib/utils";
 require("dotenv").config();
 
 const NotifyKey = process.env.REACT_APP_NOTIFY_KEY;
@@ -115,6 +116,12 @@ const Order: React.FC = (props) => {
     ) => {
         let signer = await provider.getSigner();
         let tx = await create(signer, asset, isCallType, expiry, strike);
+        notifyInstance.hash(tx.hash);
+    };
+
+    const handleMintTestToken = async (provider, tokenAddress, quantity) => {
+        let signer = await provider.getSigner();
+        let tx = await mintTestToken(signer, tokenAddress, quantity);
         notifyInstance.hash(tx.hash);
     };
 

--- a/src/contexts/Order/context.ts
+++ b/src/contexts/Order/context.ts
@@ -46,6 +46,11 @@ const OrderContext = createContext<OrderContextValues>({
         expiry: string,
         strike: number
     ) => {},
+    mintTestTokens: async (
+        provider: any,
+        optionAddress: string,
+        quantity: number | undefined
+    ) => {},
 });
 
 export default OrderContext;

--- a/src/contexts/Order/types.ts
+++ b/src/contexts/Order/types.ts
@@ -41,6 +41,11 @@ export interface OrderContextValues {
         expiry: string,
         strike: number
     ) => Promise<void>;
+    mintTestTokens: (
+        provider: any,
+        optionAddress: string,
+        quantity: number
+    ) => Promise<void>;
 }
 
 export interface OrderItem {

--- a/src/lib/primitive.ts
+++ b/src/lib/primitive.ts
@@ -1,4 +1,5 @@
 import ERC20 from "@primitivefi/contracts/artifacts/ERC20.json";
+import TestERC20 from "@primitivefi/contracts/artifacts/TestERC20.json";
 import Option from "@primitivefi/contracts/artifacts/Option.json";
 import Trader from "@primitivefi/contracts/artifacts/Trader.json";
 import Registry from "@primitivefi/contracts/artifacts/Registry.json";
@@ -11,6 +12,33 @@ import { parseEther } from "ethers/lib/utils";
 import Assets from "../contexts/Options/assets.json";
 
 const MIN_ALLOWANCE = parseEther("10000000");
+
+const mintTestToken = async (signer, optionAddress, quantity) => {
+    const option = new ethers.Contract(optionAddress, Option.abi, signer);
+    const underlyingAddress = await option.getUnderlyingTokenAddress();
+    const strikeAddress = await option.getStrikeTokenAddress();
+    const underlyingToken = new ethers.Contract(
+        underlyingAddress,
+        TestERC20.abi,
+        signer
+    );
+    const strikeToken = new ethers.Contract(
+        strikeAddress,
+        TestERC20.abi,
+        signer
+    );
+    const account = await signer.getAddress();
+    const mintQuantity = parseEther(quantity.toString()).toString();
+    let tx;
+    try {
+        tx = await underlyingToken.mint(account, mintQuantity);
+        await strikeToken.mint(account, mintQuantity);
+    } catch (err) {
+        console.log("Error when minting test token: ", err);
+    }
+
+    return tx;
+};
 
 const checkAllowance = async (signer, tokenAddress, spenderAddress) => {
     let token = new ethers.Contract(tokenAddress, ERC20.abi, signer);
@@ -193,4 +221,4 @@ const create = async (signer, underlying, isCallType, expiry, strike) => {
     return tx;
 };
 
-export { mint, exercise, redeem, close, create };
+export { mint, exercise, redeem, close, create, mintTestToken };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,7 @@
+import ERC20 from "@primitivefi/contracts/artifacts/ERC20.json";
+import { ethers } from "ethers";
+import { parseEther } from "ethers/lib/utils";
+
 const destructureOptionSymbol = (symbol) => {
     // symbol = ASSET yyyy mm dd TYPE STRIKE
     // 0-5 asset
@@ -17,4 +21,18 @@ const destructureOptionSymbol = (symbol) => {
     return { asset, year, month, day, type, strike };
 };
 
-export { destructureOptionSymbol };
+const mintTestToken = async (signer, tokenAddress, quantity) => {
+    const token = new ethers.Contract(tokenAddress, ERC20.abi, signer);
+    const account = await signer.getAccount();
+    const mintQuantity = parseEther(quantity).toString();
+    let tx;
+    try {
+        tx = await token.mint(account, mintQuantity);
+    } catch (err) {
+        console.log("Error when minting test token: ", err);
+    }
+
+    return tx;
+};
+
+export { destructureOptionSymbol, mintTestToken };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,3 @@
-import ERC20 from "@primitivefi/contracts/artifacts/ERC20.json";
-import { ethers } from "ethers";
-import { parseEther } from "ethers/lib/utils";
-
 const destructureOptionSymbol = (symbol) => {
     // symbol = ASSET yyyy mm dd TYPE STRIKE
     // 0-5 asset
@@ -21,18 +17,4 @@ const destructureOptionSymbol = (symbol) => {
     return { asset, year, month, day, type, strike };
 };
 
-const mintTestToken = async (signer, tokenAddress, quantity) => {
-    const token = new ethers.Contract(tokenAddress, ERC20.abi, signer);
-    const account = await signer.getAccount();
-    const mintQuantity = parseEther(quantity).toString();
-    let tx;
-    try {
-        tx = await token.mint(account, mintQuantity);
-    } catch (err) {
-        console.log("Error when minting test token: ", err);
-    }
-
-    return tx;
-};
-
-export { destructureOptionSymbol, mintTestToken };
+export { destructureOptionSymbol };

--- a/src/views/Market/components/OrderCard/OrderCard.tsx
+++ b/src/views/Market/components/OrderCard/OrderCard.tsx
@@ -27,6 +27,7 @@ const OrderCard: React.FC<OrderCardProps> = (props) => {
         exerciseOptions,
         orderType,
         loadPendingTx,
+        mintTestTokens,
     } = useOrders();
     const { buyOrMint } = orderType;
     const { library } = useWeb3React();
@@ -49,9 +50,18 @@ const OrderCard: React.FC<OrderCardProps> = (props) => {
         setBuyCard(!buyCard);
     };
 
+    const handleMintTestTokens = async () => {
+        await mintTestTokens(
+            library,
+            "0xBa8980CA505E7f48a177BBfA3AB90c9F01699110",
+            100
+        );
+    };
+
     return (
         <Card>
             <CardTitle>Your Order</CardTitle>
+            <Button onClick={handleMintTestTokens} text={"Get Test Tokens"} />
             <CardContent>
                 {buyOrMint ? (
                     <>


### PR DESCRIPTION
## Description
- Adds a button in the OrderCard component to mint underlying and strike tokens on Rinkeby testnet.
- Mints a default amount of 100 to the underlying and strike tokens of a hardcoded option.

## Improvements
- Needs to mint the correct assets depending on which market view the user is on.