### PR TITLE
Removes testnet button from order card, moves below.

### DIFF
--- a/src/views/Market/Market.tsx
+++ b/src/views/Market/Market.tsx
@@ -11,6 +11,7 @@ import MarketHeader from "./components/MarketHeader";
 import OptionsTable from "./components/OptionsTable";
 import PositionsTable from "./components/PositionsTable";
 import OrderCard from "./components/OrderCard";
+import TestnetCard from "./components/TestnetCard";
 import PositionsHeader from "./components/PositionsHeader";
 
 import { useWeb3React } from "@web3-react/core";
@@ -28,7 +29,7 @@ const Market: React.FC = () => {
     const [callPutActive, setCallPutActive] = useState(true);
 
     // Web3
-    const { activate } = useWeb3React();
+    const { activate, chainId } = useWeb3React();
     // Connect to web3 automatically using injected
     useEffect(() => {
         (async () => {
@@ -72,6 +73,7 @@ const Market: React.FC = () => {
                             </StyledMain>
                             <StyledSideBar>
                                 <OrderCard />
+                                {chainId === 4 ? <TestnetCard /> : <> </>}
                             </StyledSideBar>
                         </StyledMarket>
                     </PositionsProvider>

--- a/src/views/Market/components/OrderCard/OrderCard.tsx
+++ b/src/views/Market/components/OrderCard/OrderCard.tsx
@@ -27,7 +27,6 @@ const OrderCard: React.FC<OrderCardProps> = (props) => {
         exerciseOptions,
         orderType,
         loadPendingTx,
-        mintTestTokens,
     } = useOrders();
     const { buyOrMint } = orderType;
     const { library } = useWeb3React();
@@ -50,18 +49,9 @@ const OrderCard: React.FC<OrderCardProps> = (props) => {
         setBuyCard(!buyCard);
     };
 
-    const handleMintTestTokens = async () => {
-        await mintTestTokens(
-            library,
-            "0xBa8980CA505E7f48a177BBfA3AB90c9F01699110",
-            100
-        );
-    };
-
     return (
         <Card>
             <CardTitle>Your Order</CardTitle>
-            <Button onClick={handleMintTestTokens} text={"Get Test Tokens"} />
             <CardContent>
                 {buyOrMint ? (
                     <>

--- a/src/views/Market/components/TestnetCard/TestnetCard.tsx
+++ b/src/views/Market/components/TestnetCard/TestnetCard.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import Button from "../../../../components/Button";
+
+import useOrders from "../../../../hooks/useOrders";
+import { useWeb3React } from "@web3-react/core";
+
+interface TestnetCardProps {}
+
+const TestnetCard: React.FC<TestnetCardProps> = () => {
+    const { item, loadPendingTx, mintTestTokens } = useOrders();
+    const { library } = useWeb3React();
+    useEffect(() => {}, [item]);
+    useEffect(() => {
+        (async () => {
+            loadPendingTx();
+        })();
+    }, [loadPendingTx]);
+
+    const handleMintTestTokens = async () => {
+        await mintTestTokens(
+            library,
+            "0xBa8980CA505E7f48a177BBfA3AB90c9F01699110",
+            100
+        );
+    };
+
+    return (
+        <StyledContainer>
+            <Button onClick={handleMintTestTokens} text={"Get Test Tokens"} />
+        </StyledContainer>
+    );
+};
+
+const StyledContainer = styled.div`
+    margin-top: 24px;
+    display: flex;
+    justify-content: center;
+`;
+
+export default TestnetCard;

--- a/src/views/Market/components/TestnetCard/index.ts
+++ b/src/views/Market/components/TestnetCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TestnetCard";


### PR DESCRIPTION
## Description
- Removes "Get Testnet Tokens" from Order Card
- Adds "Get Testnet Tokens" below Order Card, in Sidebar
- Conditionally renders based on if connected to Rinkeby testnet