### PR TITLE
Feature/market header

### DIFF
--- a/src/contexts/Prices/Prices.tsx
+++ b/src/contexts/Prices/Prices.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useReducer } from 'react'
 
 import PricesContext from './context'
-import pricesReducer, { initialState, setPrices } from './reducer'
-import { PricesData } from './types'
+import pricesReducer, { initialState, setPrices, setAssets } from './reducer'
+import { AssetsData, PricesData } from './types'
 
 const Prices: React.FC = (props) => {
   const [state, dispatch] = useReducer(pricesReducer, initialState)
@@ -10,6 +10,7 @@ const Prices: React.FC = (props) => {
   const handlePrices = useCallback(
     async (asset) => {
       let pricesData: PricesData = {}
+      let assetsData: AssetsData = {}
       const priceAPI = `https://api.coingecko.com/api/v3/simple/price?ids=${asset}&vs_currencies=usd&include_24hr_change=true`
       fetch(priceAPI)
         .then((res) => res.json())
@@ -17,10 +18,15 @@ const Prices: React.FC = (props) => {
           (result) => {
             let key = Object.keys(result)[0]
             let price = result[key].usd
+            let asset = result[key]
             Object.assign(pricesData, {
               [key]: price,
             })
+            Object.assign(assetsData, {
+              [key]: asset,
+            })
             dispatch(setPrices(pricesData))
+            dispatch(setAssets(assetsData))
           },
           // Note: it's important to handle errors here
           // instead of a catch() block so that we don't swallow
@@ -41,6 +47,7 @@ const Prices: React.FC = (props) => {
       value={{
         prices: state.prices,
         getPrices: handlePrices,
+        assets: state.assets,
       }}
     >
       {props.children}

--- a/src/contexts/Prices/context.ts
+++ b/src/contexts/Prices/context.ts
@@ -5,6 +5,7 @@ import { PricesContextValues } from './types'
 const PricesContext = createContext<PricesContextValues>({
   prices: {},
   getPrices: (asset: string) => {},
+  assets: {},
 })
 
 export default PricesContext

--- a/src/contexts/Prices/reducer.ts
+++ b/src/contexts/Prices/reducer.ts
@@ -1,21 +1,35 @@
-import { PricesData, PricesState } from './types'
+import { PricesData, PricesState, AssetsData } from './types'
 
 export const SET_PRICES = 'SET_PRICES'
+export const SET_ASSETS = 'SET_ASSETS'
 
 export interface SetPricesAction {
   type: typeof SET_PRICES
   prices: PricesData
 }
 
-export type PricesActions = SetPricesAction
+export interface SetAssetsAction {
+  type: typeof SET_ASSETS
+  assets: AssetsData
+}
+
+export type PricesActions = SetPricesAction | SetAssetsAction
 export const initialState: PricesState = {
   prices: {},
+  assets: {},
 }
 
 export const setPrices = (pricesData: PricesData): SetPricesAction => {
   return {
     type: SET_PRICES,
     prices: pricesData,
+  }
+}
+
+export const setAssets = (assetsData: AssetsData): SetAssetsAction => {
+  return {
+    type: SET_ASSETS,
+    assets: assetsData,
   }
 }
 
@@ -27,6 +41,14 @@ const reducer = (state: PricesState, action: PricesActions) => {
         prices: {
           ...state.prices,
           ...action.prices,
+        },
+      }
+    case SET_ASSETS:
+      return {
+        ...state,
+        assets: {
+          ...state.assets,
+          ...action.assets,
         },
       }
     default:

--- a/src/contexts/Prices/types.ts
+++ b/src/contexts/Prices/types.ts
@@ -1,11 +1,17 @@
 export interface PricesContextValues {
   prices: PricesData
   getPrices: (asset: string) => void
+  assets: AssetsData
 }
 export interface PricesData {
   [key: string]: number
 }
 
+export interface AssetsData {
+  [key: string]: Object
+}
+
 export interface PricesState {
   prices: PricesData
+  assets: AssetsData
 }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -8,6 +8,7 @@ const theme = {
     black,
     grey,
     white,
+    green,
     primary: {
       light: red[200],
       main: red[500],
@@ -23,7 +24,8 @@ const theme = {
     3: 16,
     4: 24,
     5: 32,
-    6: 48,
+    6: 40,
+    7: 48,
   },
 }
 

--- a/src/views/Market/components/FilterBar/FilterBar.tsx
+++ b/src/views/Market/components/FilterBar/FilterBar.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import LitContainer from 'components/LitContainer'
 import Toggle from 'components/Toggle'
 import ToggleButton from 'components/ToggleButton'
+import Spacer from 'components/Spacer'
 
 export interface FilterBarProps {
   active: boolean
@@ -33,11 +34,31 @@ const FilterBar: React.FC<FilterBarProps> = (props) => {
               text="Puts"
             />
           </Toggle>
+          <Spacer size="lg" />
+          <StyledSelect>
+            <StyledOption>November 2</StyledOption>
+          </StyledSelect>
         </StyledFilterBarInner>
       </LitContainer>
     </StyledFilterBar>
   )
 }
+
+const StyledSelect = styled.select`
+  align-items: center;
+  display: flex;
+  border-radius: ${(props) => props.theme.borderRadius}px;
+  border: none;
+  background: ${(props) => props.theme.color.black};
+  color: ${(props) => props.theme.color.grey[400]};
+  padding: ${(props) => props.theme.spacing[3]}px;
+  width: calc(
+    (100vw - ${(props) => props.theme.contentWidth}px) / 2 +
+      ${(props) => props.theme.contentWidth * (2 / 3)}px
+  );
+  margin-right: ${(props) => props.theme.spacing[7]}px;
+`
+const StyledOption = styled.option``
 
 const StyledFilterBar = styled.div`
   background: ${(props) => props.theme.color.grey[800]};

--- a/src/views/Market/components/MarketHeader/MarketHeader.tsx
+++ b/src/views/Market/components/MarketHeader/MarketHeader.tsx
@@ -33,13 +33,17 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
     getPrices(name.toLowerCase())
   }, [name, getPrices])
 
+  const source = 'coingecko'
+
   return (
     <StyledHeader>
       <LitContainer>
         <GoBack to="/markets" />
         <StyledTitle>
-          <StyledName>{name}</StyledName>
-          <StyledSymbol>{symbol}</StyledSymbol>
+          <StyledName>
+            {name.charAt(0).toUpperCase() + name.slice(1)}
+          </StyledName>
+          <StyledSymbol>{symbol.toUpperCase()}</StyledSymbol>
         </StyledTitle>
         <StyledPrice>
           {prices[name.toLowerCase()] ? (
@@ -48,6 +52,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
             <StyledLoadingBlock />
           )}
         </StyledPrice>
+        <StyledSource>{source}</StyledSource>
       </LitContainer>
     </StyledHeader>
   )
@@ -84,9 +89,16 @@ const StyledSymbol = styled.span`
   text-transform: uppercase;
 `
 
+const StyledSource = styled.span`
+  color: ${(props) => props.theme.color.grey[400]};
+  letter-spacing: 1px;
+  font-size: 12px;
+`
+
 const StyledPrice = styled.span`
   font-size: 24px;
   font-weight: 700;
+  margin-right: ${(props) => props.theme.spacing[2]}px;
 `
 
 export default MarketHeader

--- a/src/views/Market/components/MarketHeader/MarketHeader.tsx
+++ b/src/views/Market/components/MarketHeader/MarketHeader.tsx
@@ -34,10 +34,10 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
     getPrices(name)
     let refreshInterval = setInterval(() => {
       getPrices(name)
-      setBlink((b) => !b)
+      setBlink(!blink)
     }, 5000)
     return () => clearInterval(refreshInterval)
-  }, [name, getPrices])
+  }, [name, getPrices, blink])
 
   const source = 'coingecko'
 
@@ -116,7 +116,7 @@ interface StyledPriceProps {
 
 const StyledPrice = styled.span<StyledPriceProps>`
   font-size: ${(props) =>
-    props.size === 'lg' ? 36 : props.size == 'sm' ? 16 : 24}px;
+    props.size === 'lg' ? 36 : props.size === 'sm' ? 16 : 24}px;
   font-weight: 700;
   margin-right: ${(props) => props.theme.spacing[2]}px;
   color: ${(props) =>

--- a/src/views/Market/components/MarketHeader/MarketHeader.tsx
+++ b/src/views/Market/components/MarketHeader/MarketHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import GoBack from '../../../../components/GoBack'
@@ -11,6 +11,7 @@ export interface MarketHeaderProps {
 }
 
 const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
+  const [blink, setBlink] = useState(true)
   const { marketId } = props
 
   const getMarketDetails = () => {
@@ -31,7 +32,12 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
 
   useEffect(() => {
     getPrices(name.toLowerCase())
-  }, [name, getPrices])
+    let refreshInterval = setInterval(() => {
+      getPrices(name.toLowerCase())
+      setBlink((b) => !b)
+    }, 5000)
+    return () => clearInterval(refreshInterval)
+  }, [name, getPrices, prices])
 
   const source = 'coingecko'
 
@@ -45,14 +51,16 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
           </StyledName>
           <StyledSymbol>{symbol.toUpperCase()}</StyledSymbol>
         </StyledTitle>
-        <StyledPrice>
+        <StyledPrice blink={true}>
           {prices[name.toLowerCase()] ? (
-            `$${prices[name.toLowerCase()]}`
+            `$${(+prices[name.toLowerCase()]).toFixed(2)}`
           ) : (
             <StyledLoadingBlock />
           )}
         </StyledPrice>
-        <StyledSource>{source}</StyledSource>
+        <StyledSource>
+          {source} {blink ? 'true' : 'false'}
+        </StyledSource>
       </LitContainer>
     </StyledHeader>
   )
@@ -95,10 +103,16 @@ const StyledSource = styled.span`
   font-size: 12px;
 `
 
-const StyledPrice = styled.span`
+interface StyledPriceProps {
+  blink?: boolean
+}
+
+const StyledPrice = styled.span<StyledPriceProps>`
   font-size: 24px;
   font-weight: 700;
   margin-right: ${(props) => props.theme.spacing[2]}px;
+  color: ${(props) =>
+    props.blink ? props.theme.color.green : props.theme.color.grey[400]};
 `
 
 export default MarketHeader

--- a/src/views/Market/components/MarketHeader/MarketHeader.tsx
+++ b/src/views/Market/components/MarketHeader/MarketHeader.tsx
@@ -28,16 +28,16 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
 
   const { name, symbol } = getMarketDetails()
 
-  const { prices, getPrices } = usePrices()
+  const { prices, assets, getPrices } = usePrices()
 
   useEffect(() => {
-    getPrices(name.toLowerCase())
+    getPrices(name)
     let refreshInterval = setInterval(() => {
-      getPrices(name.toLowerCase())
+      getPrices(name)
       setBlink((b) => !b)
     }, 5000)
     return () => clearInterval(refreshInterval)
-  }, [name, getPrices, prices])
+  }, [name, getPrices])
 
   const source = 'coingecko'
 
@@ -52,15 +52,21 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
           <StyledSymbol>{symbol.toUpperCase()}</StyledSymbol>
         </StyledTitle>
         <StyledPrice blink={true}>
-          {prices[name.toLowerCase()] ? (
-            `$${(+prices[name.toLowerCase()]).toFixed(2)}`
+          {prices[name] ? (
+            `$${(+prices[name]).toFixed(2)}`
           ) : (
             <StyledLoadingBlock />
           )}
         </StyledPrice>
-        <StyledSource>
-          {source} {blink ? 'true' : 'false'}
-        </StyledSource>
+        <StyledPrice blink={true} size="sm">
+          {assets[name] ? (
+            `${+assets[name]['usd_24h_change'] > 0 ? '+' : '-'}` +
+            `${(+assets[name]['usd_24h_change']).toFixed(2)}% Today`
+          ) : (
+            <StyledLoadingBlock />
+          )}
+        </StyledPrice>
+        <StyledSource>{source}</StyledSource>
       </LitContainer>
     </StyledHeader>
   )
@@ -104,15 +110,19 @@ const StyledSource = styled.span`
 `
 
 interface StyledPriceProps {
+  size?: 'sm' | 'md' | 'lg'
   blink?: boolean
 }
 
 const StyledPrice = styled.span<StyledPriceProps>`
-  font-size: 24px;
+  font-size: ${(props) =>
+    props.size === 'lg' ? 36 : props.size == 'sm' ? 16 : 24}px;
   font-weight: 700;
   margin-right: ${(props) => props.theme.spacing[2]}px;
   color: ${(props) =>
-    props.blink ? props.theme.color.green : props.theme.color.grey[400]};
+    props.size === 'sm'
+      ? props.theme.color.grey[400]
+      : props.theme.color.white};
 `
 
 export default MarketHeader


### PR DESCRIPTION
## Description
- Updates Prices context with new "Asset" state object. Contains the return values from coingecko api call in this structure:
```
"ethereum": {
  "usd": number,
  "usd_24h_change": number
}
```
- Adds "Today" 24h price change to Market header next to asset price
- Adds data source {coingecko} next to asset 24h change
- Adds non-functional expiration dropdown menu for each option market

## Need to still work on
- Make asset price and 24h change blink when updated! @clintonbembryjr 