### PR TITLE
Feature/polish and stage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,8 @@ import { ThemeProvider } from 'styled-components'
 import { HashRouter as Router, Switch, Route, Redirect } from 'react-router-dom'
 import { Web3ReactProvider } from '@web3-react/core'
 
-import TopBar from './components/TopBar'
+import TopBar from 'components/TopBar'
+import Footer from 'components/Footer'
 
 import Markets from './views/Markets'
 import Portfolio from './views/Portfolio'
@@ -39,6 +40,7 @@ const App: React.FC = () => {
             <Switch>
               <Route exact path="/create" component={Create} />
             </Switch>
+            <Footer />
           </Router>
         </MarketsProvider>
       </Web3ReactProvider>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import Nav from './components/Nav'
+
+const Footer: React.FC = () => (
+  <StyledFooter>
+    <StyledFooterInner>
+      <Nav />
+    </StyledFooterInner>
+  </StyledFooter>
+)
+
+const StyledFooter = styled.footer`
+  align-items: flex-end;
+  display: flex;
+  justify-content: center;
+`
+const StyledFooterInner = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
+  height: ${(props) => props.theme.topBarSize}px;
+  max-width: ${(props) => props.theme.siteWidth}px;
+  width: 100%;
+  position: fixed;
+  margin-right: ${(props) => props.theme.spacing[4]}px;
+  padding: ${(props) => props.theme.spacing[4]}px;
+`
+
+export default Footer

--- a/src/components/Footer/components/Nav.tsx
+++ b/src/components/Footer/components/Nav.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Nav: React.FC = () => {
+  return (
+    <StyledNav>
+      <StyledLink href="https://discord.gg/JBM6APT">
+        <img
+          height="24px"
+          width="24px"
+          alt="discord logo"
+          src={
+            'https://discord.com/assets/28174a34e77bb5e5310ced9f95cb480b.png'
+          }
+        />
+      </StyledLink>
+      <StyledLink href="https://github.com/primitivefinance">
+        <img
+          height="24px"
+          width="24px"
+          alt="discord logo"
+          src={'https://avatars1.githubusercontent.com/u/9919?s=200&v=4'}
+        />
+      </StyledLink>
+      <StyledLink href="https://twitter.com/primitivefi">
+        <img
+          height="20px"
+          width="24px"
+          alt="discord logo"
+          style={{ filter: 'brightness(0) invert(1) ' }}
+          src={
+            'https://upload.wikimedia.org/wikipedia/en/thumb/9/9f/Twitter_bird_logo_2012.svg/1280px-Twitter_bird_logo_2012.svg.png'
+          }
+        />
+      </StyledLink>
+    </StyledNav>
+  )
+}
+
+const StyledNav = styled.nav`
+  display: flex;
+`
+
+const StyledLink = styled.a`
+  align-items: center;
+  color: ${(props) => props.theme.color.grey[400]};
+  display: flex;
+  height: 44px;
+  justify-content: center;
+  &:hover {
+    color: ${(props) => props.theme.color.grey[500]};
+  }
+  text-decoration: none;
+  width: 44px;
+`
+
+export default Nav

--- a/src/components/Footer/components/index.ts
+++ b/src/components/Footer/components/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Nav'

--- a/src/components/Footer/index.ts
+++ b/src/components/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer'

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,19 +1,29 @@
 import React from 'react'
 import styled from 'styled-components'
 
-const Page: React.FC = ({ children }) => (
+interface PageProps {
+  children: any
+  full?: boolean
+}
+
+const Page: React.FC<PageProps> = (props) => (
   <StyledPage>
-    <StyledMain>{children}</StyledMain>
+    <StyledMain full={props.full}>{props.children}</StyledMain>
   </StyledPage>
 )
 
 const StyledPage = styled.div``
 
-const StyledMain = styled.div`
+interface StyledMainProps {
+  full?: boolean
+}
+
+const StyledMain = styled.div<StyledMainProps>`
   align-items: center;
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - ${(props) => props.theme.topBarSize * 2}px);
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
+  width: 100%;
 `
 
 export default Page

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -6,25 +6,30 @@ export type SelectattedSelections = {
 }
 
 export interface SelectProps {
-  selections: string[]
+  children: any
 }
 
-const Select: React.FC<SelectProps> = (props) => {
-  const { selections } = props
+const Select: React.FC<SelectProps> = ({ children }) => {
   return (
     <StyledSelect>
-      {selections.map((selection, i) => {
-        return (
-          <StyledOption key={i} value={selection}>
-            {selection}
-          </StyledOption>
-        )
-      })}
+      <StyledOption>{children}</StyledOption>
     </StyledSelect>
   )
 }
-const StyledSelect = styled.select``
-
+const StyledSelect = styled.select`
+  align-items: center;
+  display: flex;
+  border-radius: ${(props) => props.theme.borderRadius}px;
+  border: none;
+  background: ${(props) => props.theme.color.black};
+  color: ${(props) => props.theme.color.grey[400]};
+  padding: ${(props) => props.theme.spacing[3]}px;
+  width: calc(
+    (100vw - ${(props) => props.theme.contentWidth}px) / 2 +
+      ${(props) => props.theme.contentWidth * (2 / 3)}px
+  );
+  margin-right: ${(props) => props.theme.spacing[7]}px;
+`
 const StyledOption = styled.option``
 
 export default Select

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -9,6 +9,8 @@ import Container from '../Container'
 import IconButton from '../IconButton'
 import Logo from '../Logo'
 
+import PrimitiveIcon from '../../assets/img/primitive-logo.svg'
+
 import { useWeb3React } from '@web3-react/core'
 import { InjectedConnector } from '@web3-react/injected-connector'
 
@@ -38,7 +40,12 @@ const TopBar: React.FC = () => {
     <StyledTopBar>
       <Container alignItems="center" display="flex" height={72}>
         <StyledFlex>
-          <Logo />
+          <StyledNavItem to="/">
+            <StyledLogo src={PrimitiveIcon} alt="Primitive Logo" />
+          </StyledNavItem>
+          <StyledNavItem active to="/">
+            <Logo />
+          </StyledNavItem>
         </StyledFlex>
         <StyledNav>
           <StyledNavItem
@@ -113,6 +120,11 @@ const StyledNavItem = styled(Link)<StyledNavItemProps>`
   &:hover {
     color: ${(props) => props.theme.color.white};
   }
+`
+
+const StyledLogo = styled.img`
+  width: ${(props) => props.theme.spacing[5]}px;
+  height: ${(props) => props.theme.spacing[5]}px;
 `
 
 export default TopBar

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -40,7 +40,7 @@ const TopBar: React.FC = () => {
     <StyledTopBar>
       <Container alignItems="center" display="flex" height={72}>
         <StyledFlex>
-          <StyledNavItem to="/">
+          <StyledNavItem active to="/">
             <StyledLogo src={PrimitiveIcon} alt="Primitive Logo" />
           </StyledNavItem>
           <StyledNavItem active to="/">
@@ -108,7 +108,7 @@ const StyledNav = styled.div`
 `
 
 interface StyledNavItemProps {
-  active?: boolean
+  active: boolean
 }
 
 const StyledNavItem = styled(Link)<StyledNavItemProps>`

--- a/src/contexts/Markets/Markets.tsx
+++ b/src/contexts/Markets/Markets.tsx
@@ -42,6 +42,10 @@ const Markets: React.FC = ({ children }) => {
         tokenKey = 'weth'
       }
 
+      if (tokenKey === 'soon' || tokenKey === 'future') {
+        tokenKey = 'tbd'
+      }
+
       try {
         marketsArr.push({
           name: NAME_FOR_POOL[marketKey],

--- a/src/views/Create/Create.tsx
+++ b/src/views/Create/Create.tsx
@@ -11,7 +11,7 @@ import PositionsProvider from '../../contexts/Positions'
 import { useWeb3React } from '@web3-react/core'
 import { InjectedConnector } from '@web3-react/injected-connector'
 
-import CreateCard from './components/CreateCard'
+//import CreateCard from './components/CreateCard'
 
 const Create: React.FC = () => {
   // Web3
@@ -25,13 +25,16 @@ const Create: React.FC = () => {
     if (active) {
       ;(async () => {
         try {
+          const injected = new InjectedConnector({
+            supportedChainIds: [1, 3, 4, 5, 42],
+          })
           await activate(injected)
         } catch (err) {
           console.log(err)
         }
       })()
     }
-  }, [active, activate, chainId, injected])
+  }, [active, activate, chainId])
 
   const handleUnlock = () => {
     activate(injected)
@@ -46,7 +49,14 @@ const Create: React.FC = () => {
               <StyledMain>
                 {active ? (
                   chainId === 4 ? (
-                    <CreateCard />
+                    <>
+                      <WaitingRoom>
+                        {' '}
+                        Primitive is permissionless; anyone can create new
+                        Oracle-less options from the protocol's factory. The
+                        interface for this is being built.{' '}
+                      </WaitingRoom>
+                    </>
                   ) : (
                     <WaitingRoom>
                       {' '}
@@ -83,6 +93,10 @@ const WaitingRoom = styled.div`
   display: flex;
   justify-content: center;
   min-height: calc(100vh - 72px);
+  width: calc(
+    (100vw - ${(props) => props.theme.contentWidth}px) / 4 +
+      ${(props) => props.theme.contentWidth * (1 / 3)}px
+  );
 `
 
 export default Create

--- a/src/views/Create/Create.tsx
+++ b/src/views/Create/Create.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
 
+import Button from 'components/Button'
+
 import OrderProvider from '../../contexts/Order'
 import PricesProvider from '../../contexts/Prices'
 import OptionsProvider from '../../contexts/Options'
@@ -13,20 +15,27 @@ import CreateCard from './components/CreateCard'
 
 const Create: React.FC = () => {
   // Web3
-  const { activate } = useWeb3React()
+  const { activate, active, chainId } = useWeb3React()
+  const injected = new InjectedConnector({
+    supportedChainIds: [1, 3, 4, 5, 42],
+  })
+
   // Connect to web3 automatically using injected
   useEffect(() => {
-    ;(async () => {
-      try {
-        const injected = new InjectedConnector({
-          supportedChainIds: [1, 3, 4, 5, 42],
-        })
-        await activate(injected)
-      } catch (err) {
-        console.log(err)
-      }
-    })()
-  }, [activate])
+    if (active) {
+      ;(async () => {
+        try {
+          await activate(injected)
+        } catch (err) {
+          console.log(err)
+        }
+      })()
+    }
+  }, [active, activate, chainId, injected])
+
+  const handleUnlock = () => {
+    activate(injected)
+  }
 
   return (
     <PricesProvider>
@@ -35,7 +44,20 @@ const Create: React.FC = () => {
           <PositionsProvider>
             <StyledCreate>
               <StyledMain>
-                <CreateCard />
+                {active ? (
+                  chainId === 4 ? (
+                    <CreateCard />
+                  ) : (
+                    <WaitingRoom>
+                      {' '}
+                      Please connect to the Rinkeby test network.{' '}
+                    </WaitingRoom>
+                  )
+                ) : (
+                  <WaitingRoom>
+                    <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
+                  </WaitingRoom>
+                )}
               </StyledMain>
             </StyledCreate>
           </PositionsProvider>
@@ -50,9 +72,16 @@ const StyledMain = styled.div`
 `
 
 const StyledCreate = styled.div`
+  align-items: center;
   display: flex;
   justify-content: center;
+  min-height: calc(100vh - 72px);
+`
+
+const WaitingRoom = styled.div`
   align-items: center;
+  display: flex;
+  justify-content: center;
   min-height: calc(100vh - 72px);
 `
 

--- a/src/views/Create/Create.tsx
+++ b/src/views/Create/Create.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import styled from 'styled-components'
 
 import Button from 'components/Button'
+import Page from 'components/Page'
 
 import OrderProvider from '../../contexts/Order'
 import PricesProvider from '../../contexts/Prices'
@@ -45,31 +46,33 @@ const Create: React.FC = () => {
       <OrderProvider>
         <OptionsProvider>
           <PositionsProvider>
-            <StyledCreate>
-              <StyledMain>
-                {active ? (
-                  chainId === 4 ? (
-                    <>
+            <Page>
+              <StyledCreate>
+                <StyledMain>
+                  {active ? (
+                    chainId === 4 ? (
+                      <>
+                        <WaitingRoom>
+                          {' '}
+                          Primitive is permissionless; anyone can create new
+                          Oracle-less options from the protocol's factory. The
+                          interface for this is being built.{' '}
+                        </WaitingRoom>
+                      </>
+                    ) : (
                       <WaitingRoom>
                         {' '}
-                        Primitive is permissionless; anyone can create new
-                        Oracle-less options from the protocol's factory. The
-                        interface for this is being built.{' '}
+                        Please connect to the Rinkeby test network.{' '}
                       </WaitingRoom>
-                    </>
+                    )
                   ) : (
                     <WaitingRoom>
-                      {' '}
-                      Please connect to the Rinkeby test network.{' '}
+                      <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
                     </WaitingRoom>
-                  )
-                ) : (
-                  <WaitingRoom>
-                    <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
-                  </WaitingRoom>
-                )}
-              </StyledMain>
-            </StyledCreate>
+                  )}
+                </StyledMain>
+              </StyledCreate>
+            </Page>
           </PositionsProvider>
         </OptionsProvider>
       </OrderProvider>
@@ -85,14 +88,14 @@ const StyledCreate = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
-  min-height: calc(100vh - 72px);
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
 `
 
 const WaitingRoom = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
-  min-height: calc(100vh - 72px);
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
   width: calc(
     (100vw - ${(props) => props.theme.contentWidth}px) / 4 +
       ${(props) => props.theme.contentWidth * (1 / 3)}px

--- a/src/views/Create/components/CreateCard/CreateCard.tsx
+++ b/src/views/Create/components/CreateCard/CreateCard.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import Card from '../../../../components/Card'
-import CardContent from '../../../../components/CardContent'
-import CardTitle from '../../../../components/CardTitle'
-import Button from '../../../../components/Button'
+import Card from 'components/Card'
+import CardContent from 'components/CardContent'
+import CardTitle from 'components/CardTitle'
+import Button from 'components/Button'
+import Input from 'components/Input'
+import Spacer from 'components/Spacer'
 
 import { useWeb3React } from '@web3-react/core'
 import useOrder from '../../../../hooks/useOrders'
@@ -47,8 +49,7 @@ const CreateCard: React.FC<CreateCardProps> = (props) => {
     }
   }
 
-  const handleSubmit = async (event) => {
-    event.preventDefault()
+  const handleSubmit = () => {
     console.log('Submitting: ', { asset, expiry, strike, isCallType })
     createOption(library, asset, isCallType, expiry, strike)
   }
@@ -66,119 +67,84 @@ const CreateCard: React.FC<CreateCardProps> = (props) => {
     <Card>
       <CardTitle>Create Option</CardTitle>
       <CardContent>
-        <StyledForm onSubmit={handleSubmit}>
-          <StyledLabel>
-            Type
-            <Button
-              onClick={onToggle}
-              text={'Call'}
-              variant={!isCallType ? 'tertiary' : 'default'}
-            />
-            <Button
-              onClick={onToggle}
-              text={'Put'}
-              variant={!isCallType ? 'default' : 'tertiary'}
-            />
-          </StyledLabel>
-          <StyledLabel>
-            Underlying Asset
-            <StyledSelect
-              autoFocus
-              value={asset}
-              onChange={handleChange}
-              name="asset"
-            >
-              {assets.map((selection, i) => {
-                return (
-                  <StyledOption key={i} value={Assets[selection][chainId]}>
-                    {selection}
-                  </StyledOption>
-                )
-              })}
-            </StyledSelect>
-          </StyledLabel>
-          <Spacing />
-          <StyledLabel>
-            Expiry
-            <StyledSelect value={expiry} onChange={handleChange} name="expiry">
-              {expiries.map((selection, i) => {
-                return (
-                  <StyledOption key={i} value={selection}>
-                    {getSimpleDate(selection)}
-                  </StyledOption>
-                )
-              })}
-            </StyledSelect>
-          </StyledLabel>
-          <Spacing />
-          <StyledLabel>
-            Strike Price
-            <StyledInput
-              type="number"
-              placeholder="0.00"
-              onChange={handleChange}
-              name="strike"
-            ></StyledInput>
-          </StyledLabel>
-          <Spacing />
-          <StyledInput type="submit" value="Create Option"></StyledInput>
-        </StyledForm>
+        <StyledFilter>
+          <StyledLabel>Type</StyledLabel>
+          <Spacer />
+          <Button
+            onClick={onToggle}
+            text={'Call'}
+            variant={!isCallType ? 'tertiary' : 'default'}
+          />
+          <Button
+            onClick={onToggle}
+            text={'Put'}
+            variant={!isCallType ? 'default' : 'tertiary'}
+          />
+        </StyledFilter>
+        <Spacer />
+        <StyledLabel>
+          Underlying Asset
+          <StyledSelect
+            autoFocus
+            value={asset}
+            onChange={handleChange}
+            name="asset"
+          >
+            {assets.map((selection, i) => {
+              return (
+                <StyledOption key={i} value={Assets[selection][chainId]}>
+                  {selection}
+                </StyledOption>
+              )
+            })}
+          </StyledSelect>
+        </StyledLabel>
+        <Spacer />
+        <StyledLabel>
+          Expiry
+          <StyledSelect value={expiry} onChange={handleChange} name="expiry">
+            {expiries.map((selection, i) => {
+              return (
+                <StyledOption key={i} value={selection}>
+                  {getSimpleDate(selection)}
+                </StyledOption>
+              )
+            })}
+          </StyledSelect>
+        </StyledLabel>
+        <Spacer />
+        <StyledLabel>
+          Strike Price
+          <Input placeholder="0.00" onChange={handleChange}></Input>
+        </StyledLabel>
+        <Spacer />
+        <Button disabled onClick={handleSubmit} text="Create Option" />
       </CardContent>
     </Card>
   )
 }
 
-const Spacing = styled.div`
-  min-width: 1em;
-  min-height: 1em;
-`
-
-const StyledForm = styled.form`
-  display: flex;
-  flex-direction: column;
-`
 const StyledSelect = styled.select`
+  align-items: center;
   display: flex;
-  justify-content: space-evenly;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-sizing: border-box;
-
+  border-radius: ${(props) => props.theme.borderRadius}px;
   border: none;
-  border-bottom: 0.5px solid #bdbdbd;
-
-  font-size: 1em;
-  padding-left: 0.25em;
-  padding-top: 0.25em;
-  min-width: 10em;
-
-  :focus {
-    border-color: #5eaefe;
-    outline: none;
-  }
+  background: ${(props) => props.theme.color.black};
+  color: ${(props) => props.theme.color.grey[400]};
+  padding: ${(props) => props.theme.spacing[3]}px;
+  width: calc(
+    (100vw - ${(props) => props.theme.contentWidth}px) / 4 +
+      ${(props) => props.theme.contentWidth * (1 / 8)}px
+  );
+  margin-right: ${(props) => props.theme.spacing[7]}px;
 `
 const StyledOption = styled.option``
-const StyledInput = styled.input`
+
+const StyledFilter = styled.div`
   display: flex;
-  justify-content: space-evenly;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-sizing: border-box;
-
-  border: none;
-  border-bottom: 0.5px solid #bdbdbd;
-
-  font-size: 1em;
-  padding-left: 0.25em;
-  padding-top: 0.25em;
-  min-width: 10em;
-
-  :focus {
-    border-color: #5eaefe;
-    outline: none;
-  }
+  flex: 1;
+  flex-direction: row;
+  width: 100%;
 `
 const StyledLabel = styled.label``
 

--- a/src/views/Market/Market.tsx
+++ b/src/views/Market/Market.tsx
@@ -7,6 +7,8 @@ import PricesProvider from '../../contexts/Prices'
 import OptionsProvider from '../../contexts/Options'
 import PositionsProvider from '../../contexts/Positions'
 
+import Page from 'components/Page'
+
 import FilterBar from './components/FilterBar'
 import MarketHeader from './components/MarketHeader'
 import OptionsTable from './components/OptionsTable'
@@ -69,46 +71,48 @@ const Market: React.FC = () => {
       <OrderProvider>
         <OptionsProvider>
           <PositionsProvider>
-            <StyledMarket>
-              {active ? (
-                chainId === 4 ? (
-                  <>
-                    <StyledMain>
-                      <MarketHeader marketId={marketId} />
-                      <FilterBar
-                        active={callPutActive}
-                        setCallActive={handleFilter}
-                      />
-                      <OptionsTable
-                        options={mockOptions}
-                        asset="Ethereum"
-                        callActive={callPutActive}
-                      />
-                      <PositionsHeader name="Ethereum" symbol="ETH" />
-                      <PositionsTable
-                        positions={mockOptions}
-                        asset="Ethereum"
-                        callActive={callPutActive}
-                      />
-                    </StyledMain>
-                    <StyledSideBar>
-                      <OrderCard />
-                      <Spacer />
-                      {chainId === 4 ? <TestnetCard /> : <> </>}
-                    </StyledSideBar>{' '}
-                  </>
+            <Page>
+              <StyledMarket>
+                {active ? (
+                  chainId === 4 ? (
+                    <>
+                      <StyledMain>
+                        <MarketHeader marketId={marketId} />
+                        <FilterBar
+                          active={callPutActive}
+                          setCallActive={handleFilter}
+                        />
+                        <OptionsTable
+                          options={mockOptions}
+                          asset="Ethereum"
+                          callActive={callPutActive}
+                        />
+                        <PositionsHeader name="Ethereum" symbol="ETH" />
+                        <PositionsTable
+                          positions={mockOptions}
+                          asset="Ethereum"
+                          callActive={callPutActive}
+                        />
+                      </StyledMain>
+                      <StyledSideBar>
+                        <OrderCard />
+                        <Spacer />
+                        {chainId === 4 ? <TestnetCard /> : <> </>}
+                      </StyledSideBar>{' '}
+                    </>
+                  ) : (
+                    <WaitingRoom>
+                      {' '}
+                      Please connect to the Rinkeby test network.{' '}
+                    </WaitingRoom>
+                  )
                 ) : (
                   <WaitingRoom>
-                    {' '}
-                    Please connect to the Rinkeby test network.{' '}
+                    <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
                   </WaitingRoom>
-                )
-              ) : (
-                <WaitingRoom>
-                  <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
-                </WaitingRoom>
-              )}
-            </StyledMarket>
+                )}
+              </StyledMarket>
+            </Page>
           </PositionsProvider>
         </OptionsProvider>
       </OrderProvider>
@@ -123,17 +127,19 @@ const WaitingRoom = styled.div`
   display: flex;
   font-size: 36px;
   justify-content: center;
-  min-height: calc(100vh - 72px);
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
+  width: 100%;
 `
 
 const StyledMarket = styled.div`
   display: flex;
+  width: 100%;
 `
 
 const StyledSideBar = styled.div`
   border-left: 1px solid ${(props) => props.theme.color.grey[600]};
   box-sizing: border-box;
-  min-height: calc(100vh - 72px);
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
   padding: ${(props) => props.theme.spacing[4]}px;
   width: 400px;
 `

--- a/src/views/Market/Market.tsx
+++ b/src/views/Market/Market.tsx
@@ -44,6 +44,9 @@ const Market: React.FC = () => {
   useEffect(() => {
     if (active) {
       ;(async () => {
+        const injected = new InjectedConnector({
+          supportedChainIds: [1, 3, 4, 5, 42],
+        })
         try {
           await activate(injected)
         } catch (err) {
@@ -51,7 +54,7 @@ const Market: React.FC = () => {
         }
       })()
     }
-  }, [active, activate, chainId, injected])
+  }, [active, activate, chainId])
 
   const handleFilter = () => {
     setCallPutActive(!callPutActive)

--- a/src/views/Market/Market.tsx
+++ b/src/views/Market/Market.tsx
@@ -39,21 +39,19 @@ const Market: React.FC = () => {
   const injected = new InjectedConnector({
     supportedChainIds: [1, 3, 4, 5, 42],
   })
+
   // Connect to web3 automatically using injected
   useEffect(() => {
     if (active) {
       ;(async () => {
         try {
-          const injected = new InjectedConnector({
-            supportedChainIds: [1, 3, 4, 5, 42],
-          })
           await activate(injected)
         } catch (err) {
           console.log(err)
         }
       })()
     }
-  }, [active, activate, chainId])
+  }, [active, activate, chainId, injected])
 
   const handleFilter = () => {
     setCallPutActive(!callPutActive)
@@ -118,10 +116,11 @@ const Market: React.FC = () => {
 const StyledMain = styled.div``
 
 const WaitingRoom = styled.div`
-  display: flex;
-  min-height: calc(100vh - 72px);
-  justify-content: center;
   align-items: center;
+  display: flex;
+  font-size: 36px;
+  justify-content: center;
+  min-height: calc(100vh - 72px);
 `
 
 const StyledMarket = styled.div`

--- a/src/views/Market/Market.tsx
+++ b/src/views/Market/Market.tsx
@@ -15,6 +15,7 @@ import OrderCard from './components/OrderCard'
 import TestnetCard from './components/TestnetCard'
 import PositionsHeader from './components/PositionsHeader'
 import Spacer from 'components/Spacer'
+import Button from 'components/Button'
 
 import { useWeb3React } from '@web3-react/core'
 import { InjectedConnector } from '@web3-react/injected-connector'
@@ -34,53 +35,78 @@ const Market: React.FC = () => {
   const { marketId } = useParams()
 
   // Web3
-  const { activate, chainId } = useWeb3React()
+  const { activate, chainId, active } = useWeb3React()
+  const injected = new InjectedConnector({
+    supportedChainIds: [1, 3, 4, 5, 42],
+  })
   // Connect to web3 automatically using injected
   useEffect(() => {
-    ;(async () => {
-      try {
-        const injected = new InjectedConnector({
-          supportedChainIds: [1, 3, 4, 5, 42],
-        })
-        await activate(injected)
-      } catch (err) {
-        console.log(err)
-      }
-    })()
-  }, [activate])
+    if (active) {
+      ;(async () => {
+        try {
+          const injected = new InjectedConnector({
+            supportedChainIds: [1, 3, 4, 5, 42],
+          })
+          await activate(injected)
+        } catch (err) {
+          console.log(err)
+        }
+      })()
+    }
+  }, [active, activate, chainId])
 
   const handleFilter = () => {
     setCallPutActive(!callPutActive)
   }
+
+  const handleUnlock = () => {
+    activate(injected)
+  }
+
   return (
     <PricesProvider>
       <OrderProvider>
         <OptionsProvider>
           <PositionsProvider>
             <StyledMarket>
-              <StyledMain>
-                <MarketHeader marketId={marketId} />
-                <FilterBar
-                  active={callPutActive}
-                  setCallActive={handleFilter}
-                />
-                <OptionsTable
-                  options={mockOptions}
-                  asset="Ethereum"
-                  callActive={callPutActive}
-                />
-                <PositionsHeader name="Ethereum" symbol="ETH" />
-                <PositionsTable
-                  positions={mockOptions}
-                  asset="Ethereum"
-                  callActive={callPutActive}
-                />
-              </StyledMain>
-              <StyledSideBar>
-                <OrderCard />
-                <Spacer />
-                {chainId === 4 ? <TestnetCard /> : <> </>}
-              </StyledSideBar>
+              {active ? (
+                chainId === 4 ? (
+                  <>
+                    <StyledMain>
+                      <MarketHeader marketId={marketId} />
+                      <FilterBar
+                        active={callPutActive}
+                        setCallActive={handleFilter}
+                      />
+                      <OptionsTable
+                        options={mockOptions}
+                        asset="Ethereum"
+                        callActive={callPutActive}
+                      />
+                      <PositionsHeader name="Ethereum" symbol="ETH" />
+                      <PositionsTable
+                        positions={mockOptions}
+                        asset="Ethereum"
+                        callActive={callPutActive}
+                      />
+                    </StyledMain>
+                    <StyledSideBar>
+                      <OrderCard />
+                      <Spacer />
+                      {chainId === 4 ? <TestnetCard /> : <> </>}
+                    </StyledSideBar>{' '}
+                  </>
+                ) : (
+                  <WaitingRoom>
+                    {' '}
+                    Please connect to the Rinkeby test network.{' '}
+                  </WaitingRoom>
+                )
+              ) : (
+                <WaitingRoom>
+                  <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
+                </WaitingRoom>
+              )}
             </StyledMarket>
           </PositionsProvider>
         </OptionsProvider>
@@ -90,6 +116,13 @@ const Market: React.FC = () => {
 }
 
 const StyledMain = styled.div``
+
+const WaitingRoom = styled.div`
+  display: flex;
+  min-height: calc(100vh - 72px);
+  justify-content: center;
+  align-items: center;
+`
 
 const StyledMarket = styled.div`
   display: flex;

--- a/src/views/Market/components/EmptyTable/EmptyTable.tsx
+++ b/src/views/Market/components/EmptyTable/EmptyTable.tsx
@@ -16,13 +16,13 @@ const EmptyTable: React.FC<EmptyTableProps> = (props) => {
         {props.columns.map((column, index) => {
           if (index === props.columns.length - 1) {
             return (
-              <StyledButtonCell>
+              <StyledButtonCell key={index}>
                 <StyledLoadingBlock />
               </StyledButtonCell>
             )
           }
           return (
-            <TableCell>
+            <TableCell key={index}>
               <StyledLoadingBlock />
             </TableCell>
           )

--- a/src/views/Market/components/MarketHeader/MarketHeader.tsx
+++ b/src/views/Market/components/MarketHeader/MarketHeader.tsx
@@ -37,9 +37,8 @@ const MarketHeader: React.FC<MarketHeaderProps> = (props) => {
   useEffect(() => {
     getPrices(name)
     let refreshInterval = setInterval(() => {
-      // getPrices(name)
-      setBlink(true)
-    }, 1000)
+      getPrices(name)
+    }, 10000)
     return () => clearInterval(refreshInterval)
   }, [blink, getPrices, setBlink, name])
 
@@ -139,7 +138,7 @@ const StyledPrice = styled.span<StyledPriceProps>`
     props.size === 'lg' ? 36 : props.size === 'sm' ? 16 : 24}px;
   font-weight: 700;
   margin-right: ${(props) => props.theme.spacing[2]}px;
-  text-shadow: ${(props) => (props.blink ? '0px 0px 12px #00ff89' : undefined)};
+  color: ${(props) => (props.blink ? '#00ff89' : props.theme.color.white)};
 `
 
 /*

--- a/src/views/Market/components/OptionsTable/OptionsTable.tsx
+++ b/src/views/Market/components/OptionsTable/OptionsTable.tsx
@@ -57,9 +57,11 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
           <TableRow isHead>
             {headers.map((header, index) => {
               if (index === headers.length - 1) {
-                return <StyledButtonCell>{header}</StyledButtonCell>
+                return (
+                  <StyledButtonCell key={header}>{header}</StyledButtonCell>
+                )
               }
-              return <TableCell>{header}</TableCell>
+              return <TableCell key={header}>{header}</TableCell>
             })}
           </TableRow>
         </LitContainer>
@@ -71,16 +73,16 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
               const { breakEven, price, strike, address } = option
               return (
                 <TableRow key={address}>
-                  <TableCell>${strike.toFixed(2)}</TableCell>
-                  <TableCell>${breakEven.toFixed(2)}</TableCell>
-                  <TableCell>${price.toFixed(2)}</TableCell>
-                  <TableCell>
+                  <TableCell key={strike}>${strike.toFixed(2)}</TableCell>
+                  <TableCell key={breakEven}>${breakEven.toFixed(2)}</TableCell>
+                  <TableCell key={price}>${price.toFixed(2)}</TableCell>
+                  <TableCell key={address}>
                     <StyledARef href={`${baseUrl}/${address}`}>
                       {formatAddress(address)}{' '}
                       <LaunchIcon style={{ fontSize: '14px' }} />
                     </StyledARef>
                   </TableCell>
-                  <StyledButtonCell>
+                  <StyledButtonCell key={'Open'}>
                     <Button
                       onClick={() => {
                         onAddItem(option, {

--- a/src/views/Market/components/PositionsTable/PositionsTable.tsx
+++ b/src/views/Market/components/PositionsTable/PositionsTable.tsx
@@ -74,9 +74,11 @@ const PositionsTable: React.FC<PositionsTableProps> = (props) => {
           <TableRow isHead>
             {headers.map((header, index) => {
               if (index === headers.length - 1) {
-                return <StyledButtonCell>{header}</StyledButtonCell>
+                return (
+                  <StyledButtonCell key={header}>{header}</StyledButtonCell>
+                )
               }
-              return <TableCell>{header}</TableCell>
+              return <TableCell key={header}>{header}</TableCell>
             })}
           </TableRow>
         </LitContainer>
@@ -98,16 +100,20 @@ const PositionsTable: React.FC<PositionsTableProps> = (props) => {
 
               return (
                 <TableRow key={address}>
-                  <TableCell>{asset === 'Ether' ? 'Weth' : asset}</TableCell>
-                  <TableCell>{`$${(+strike).toFixed(2)}`}</TableCell>
-                  <TableCell>{`${month}/${day}/${year}`}</TableCell>
-                  <TableCell>{balance.toFixed(2)}</TableCell>
-                  <TableCell>${price.toFixed(2)}</TableCell>
-                  <TableCell>
-                    <Timer expiry={expiry} />
+                  <TableCell key={asset}>
+                    {asset === 'Ether' ? 'Weth' : asset}
+                  </TableCell>
+                  <TableCell key={strike}>{`$${(+strike).toFixed(
+                    2
+                  )}`}</TableCell>
+                  <TableCell key={month}>{`${month}/${day}/${year}`}</TableCell>
+                  <TableCell key={balance}>{balance.toFixed(2)}</TableCell>
+                  <TableCell key={price}>${price.toFixed(2)}</TableCell>
+                  <TableCell key={expiry}>
+                    <Timer key={expiry} expiry={expiry} />
                     <FilledBar expiry={expiry} />
                   </TableCell>
-                  <StyledButtonCell>
+                  <StyledButtonCell key={'Close'}>
                     <Button
                       onClick={() => {
                         onAddItem(option, {

--- a/src/views/Market/components/TestnetCard/TestnetCard.tsx
+++ b/src/views/Market/components/TestnetCard/TestnetCard.tsx
@@ -5,11 +5,7 @@ import Button from 'components/Button'
 import Card from 'components/Card'
 import CardContent from 'components/CardContent'
 import Spacer from 'components/Spacer'
-import IconButton from 'components/IconButton'
-
-import HelpIcon from '@material-ui/icons/Help'
 import LaunchIcon from '@material-ui/icons/Launch'
-import Tooltip from '@material-ui/core/Tooltip'
 
 import useOrders from '../../../../hooks/useOrders'
 import { useWeb3React } from '@web3-react/core'

--- a/src/views/Markets/Markets.tsx
+++ b/src/views/Markets/Markets.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Route, Switch, useRouteMatch } from 'react-router-dom'
 
 import Page from '../../components/Page'
@@ -6,24 +6,119 @@ import PageHeader from '../../components/PageHeader'
 import MarketCards from './components/MarketCards'
 import Market from '../Market'
 
-import greek from '../../assets/img/greek.svg'
+const days: { [key: number]: React.ReactNode } = {
+  1: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Epsilon_uc_lc.svg/1280px-Epsilon_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  2: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Lambda_uc_lc.svg/1280px-Lambda_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  3: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/Delta_uc_lc.svg/1280px-Delta_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  4: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/9/94/Theta_uc_lc.svg/1280px-Theta_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  5: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/Gamma_uc_lc.svg/1280px-Gamma_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  6: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Phi_uc_lc.svg/1280px-Phi_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  7: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Omega_uc_lc.svg/1280px-Omega_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+  8: (
+    <img
+      height="64"
+      src={
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Pi_uc_lc.svg/1280px-Pi_uc_lc.svg.png'
+      }
+      style={{ filter: 'invert(1)' }}
+      alt={'monday greek'}
+    />
+  ),
+}
 
 const Markets: React.FC = () => {
+  const [day, setDay] = useState(0)
   const { path } = useRouteMatch()
+
+  const isItPiDay = (dateObject) => {
+    let date = dateObject.getDate()
+    let month = dateObject.getMonth()
+    if (month === 2) {
+      if (date === 14) {
+        return true
+      }
+    }
+    return false
+  }
+  useEffect(() => {
+    let date = new Date()
+    let currentDay = date.getDay()
+    if (isItPiDay(date)) {
+      setDay(8)
+    } else {
+      setDay(currentDay)
+    }
+  }, [day, setDay])
 
   return (
     <Switch>
       <Page>
         <Route exact path={path}>
           <PageHeader
-            icon={
-              <img
-                src={greek}
-                style={{ filter: 'invert(1)' }}
-                height="72"
-                alt={'markets page icon'}
-              />
-            }
+            icon={days[day]}
             subtitle="Oracle-less options."
             title="Select an option market."
           />

--- a/src/views/Markets/components/MarketCards.tsx
+++ b/src/views/Markets/components/MarketCards.tsx
@@ -62,7 +62,7 @@ const MarketCard: React.FC<MarketCardProps> = ({ market }) => {
             <CardIcon>{market.icon}</CardIcon>
             <StyledTitle>{market.name}</StyledTitle>
             <StyledDetails>
-              <StyledDetail>TKN / TKN</StyledDetail>
+              <StyledDetail>{market.id.toUpperCase()} / USD</StyledDetail>
             </StyledDetails>
             <Spacer />
             <Button

--- a/src/views/Portfolio/Portfolio.tsx
+++ b/src/views/Portfolio/Portfolio.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import Page from 'components/Page'
+
 import OrderProvider from '../../contexts/Order'
 import PricesProvider from '../../contexts/Prices'
 import OptionsProvider from '../../contexts/Options'
@@ -12,9 +14,11 @@ const Portfolio: React.FC = () => {
       <OrderProvider>
         <OptionsProvider>
           <PositionsProvider>
-            <StyledPortfolio>
-              <StyledMain>Soon</StyledMain>
-            </StyledPortfolio>
+            <Page>
+              <StyledPortfolio>
+                <StyledMain>Soon</StyledMain>
+              </StyledPortfolio>
+            </Page>
           </PositionsProvider>
         </OptionsProvider>
       </OrderProvider>
@@ -30,7 +34,7 @@ const StyledPortfolio = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: calc(100vh - 72px);
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
 `
 
 export default Portfolio


### PR DESCRIPTION
## Description
- Adds some polishing touches before staging push
- Cleans up some errors
- Conditionally renders views with web3 based on network
- Adds unlock wallet button to views that need web3 connection
- Different icons for the home 'Markets' page per day
- Added link to Primitive logo in top left of nav bar to go home
- Styles create card with current components
- Wrapped the portfolio and create views in the Page component

## To Fix
- When the 'Market' view is wrapped in Page, it does not extend the full with of the screen