### PR TITLE
Feature/homepage improvements

### DIFF
--- a/app/src/components/Button/Button.tsx
+++ b/app/src/components/Button/Button.tsx
@@ -72,7 +72,7 @@ const Button: React.FC<ButtonProps> = ({
     case 'default':
     default:
       background = color.white
-      buttonColor = color.black
+      buttonColor = color.grey[600]
       border = ''
       hoverBackgroundColor = color.white
       hoverColor = color.black

--- a/app/src/components/Container/Container.tsx
+++ b/app/src/components/Container/Container.tsx
@@ -26,9 +26,9 @@ interface StyleProps {
 const StyledContainer = styled.div<StyleProps>`
   align-items: ${(props) => props.alignItems};
   display: ${(props) => props.display};
-  flexdirection: ${(props) => props.flexDirection};
+  flex-direction: ${(props) => props.flexDirection};
   height: ${(props) => (props.height ? props.height + 'px' : undefined)};
-  justifycontent: ${(props) => props.justifyContent};
+  justify-content: ${(props) => props.justifyContent};
   margin: 0 auto;
   max-width: 1200px;
   width: 100%;

--- a/app/src/components/TopBar/TopBar.tsx
+++ b/app/src/components/TopBar/TopBar.tsx
@@ -5,9 +5,9 @@ import styled from 'styled-components'
 import AccountCircleIcon from '@material-ui/icons/AccountCircle'
 import NotificationsIcon from '@material-ui/icons/Notifications'
 
-import Container from '../Container'
-import IconButton from '../IconButton'
-import Logo from '../Logo'
+import Container from 'components/Container'
+import IconButton from 'components/IconButton'
+import Logo from 'components/Logo'
 
 import PrimitiveIcon from '../../assets/img/primitive-logo.svg'
 
@@ -91,6 +91,7 @@ const StyledTopBar = styled.div`
   border-bottom: 1px solid ${(props) => props.theme.color.grey[600]};
   color: ${(props) => props.theme.color.white};
   display: flex;
+  flex-direction: column;
   height: 72px;
 `
 

--- a/app/src/hooks/useTokenBalance.ts
+++ b/app/src/hooks/useTokenBalance.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from 'react'
+import { formatEther } from 'ethers/lib/utils'
+
+import { useWeb3React } from '@web3-react/core'
+
+import { getBalance } from '../lib/erc20'
+
+const useTokenBalance = (tokenAddress: string) => {
+  const [balance, setBalance] = useState('0')
+  const { account, library } = useWeb3React()
+
+  const fetchBalance = useCallback(async () => {
+    const balance = await getBalance(library, tokenAddress, account)
+    console.log('Balance', balance.toString(), formatEther(balance).toString())
+    setBalance(formatEther(balance).toString())
+  }, [account, library, tokenAddress])
+
+  useEffect(() => {
+    if (account && library) {
+      fetchBalance()
+      let refreshInterval = setInterval(fetchBalance, 10000)
+      return () => clearInterval(refreshInterval)
+    }
+  }, [account, library, setBalance, tokenAddress])
+
+  return balance
+}
+
+export default useTokenBalance

--- a/app/src/lib/erc20.ts
+++ b/app/src/lib/erc20.ts
@@ -1,0 +1,8 @@
+import ethers from 'ethers'
+import ERC20 from '@primitivefi/contracts/artifacts/ERC20.json'
+
+export const getBalance = async (provider, tokenAddress, account) => {
+  const erc20 = new ethers.Contract(tokenAddress, ERC20.abi, provider)
+  const balance = await erc20.balanceOf(account)
+  return balance
+}

--- a/app/src/utils/formatBalance.ts
+++ b/app/src/utils/formatBalance.ts
@@ -1,0 +1,8 @@
+const formatBalance = (tokenBalance: string) => {
+  return parseFloat(tokenBalance).toLocaleString('en', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+export default formatBalance

--- a/app/src/views/Create/Create.tsx
+++ b/app/src/views/Create/Create.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import Button from 'components/Button'
 import Page from 'components/Page'
+import Spacer from 'components/Spacer'
 
 import OrderProvider from '../../contexts/Order'
 import PricesProvider from '../../contexts/Prices'
@@ -67,7 +68,23 @@ const Create: React.FC = () => {
                     )
                   ) : (
                     <WaitingRoom>
-                      <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
+                      <Spacer size="lg" />
+                      <Button
+                        text="Connect Wallet"
+                        onClick={handleUnlock}
+                      />{' '}
+                      <Spacer size="lg" />
+                      <StyledText>
+                        This interface requires a connection from the browser to
+                        Ethereum.
+                      </StyledText>
+                      <Button
+                        size="sm"
+                        text="Learn More"
+                        variant="transparent"
+                        href="https://ethereum.org/en/wallets/"
+                      />{' '}
+                      <Spacer />
                     </WaitingRoom>
                   )}
                 </StyledMain>
@@ -84,6 +101,10 @@ const StyledMain = styled.div`
   font-size: 36px;
 `
 
+const StyledText = styled.div`
+  font-size: 18px;
+`
+
 const StyledCreate = styled.div`
   align-items: center;
   display: flex;
@@ -94,12 +115,11 @@ const StyledCreate = styled.div`
 const WaitingRoom = styled.div`
   align-items: center;
   display: flex;
+  flex-direction: column;
+  font-size: 36px;
   justify-content: center;
   min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
-  width: calc(
-    (100vw - ${(props) => props.theme.contentWidth}px) / 4 +
-      ${(props) => props.theme.contentWidth * (1 / 3)}px
-  );
+  width: 100%;
 `
 
 export default Create

--- a/app/src/views/Create/Create.tsx
+++ b/app/src/views/Create/Create.tsx
@@ -54,10 +54,11 @@ const Create: React.FC = () => {
                     chainId === 4 ? (
                       <>
                         <WaitingRoom>
-                          {' '}
-                          Primitive is permissionless; anyone can create new
-                          Oracle-less options from the protocol's factory. The
-                          interface for this is being built.{' '}
+                          <StyledText>
+                            Primitive is permissionless; anyone can create new
+                            Oracle-less options from the protocol's factory. The
+                            interface is being built.
+                          </StyledText>
                         </WaitingRoom>
                       </>
                     ) : (

--- a/app/src/views/Market/Market.tsx
+++ b/app/src/views/Market/Market.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { useParams } from 'react-router-dom'
 
+import Spacer from 'components/Spacer'
+import Button from 'components/Button'
+
 import OrderProvider from '../../contexts/Order'
 import PricesProvider from '../../contexts/Prices'
 import OptionsProvider from '../../contexts/Options'
@@ -14,8 +17,6 @@ import PositionsTable from './components/PositionsTable'
 import OrderCard from './components/OrderCard'
 import TestnetCard from './components/TestnetCard'
 import PositionsHeader from './components/PositionsHeader'
-import Spacer from 'components/Spacer'
-import Button from 'components/Button'
 
 import { useWeb3React } from '@web3-react/core'
 import { InjectedConnector } from '@web3-react/injected-connector'
@@ -105,7 +106,20 @@ const Market: React.FC = () => {
                 )
               ) : (
                 <WaitingRoom>
+                  <Spacer size="lg" />
                   <Button text="Connect Wallet" onClick={handleUnlock} />{' '}
+                  <Spacer size="lg" />
+                  <StyledText>
+                    This interface requires a connection from the browser to
+                    Ethereum.
+                  </StyledText>
+                  <Button
+                    size="sm"
+                    text="Learn More"
+                    variant="transparent"
+                    href="https://ethereum.org/en/wallets/"
+                  />{' '}
+                  <Spacer />
                 </WaitingRoom>
               )}
             </StyledMarket>
@@ -118,9 +132,14 @@ const Market: React.FC = () => {
 
 const StyledMain = styled.div``
 
+const StyledText = styled.div`
+  font-size: 18px;
+`
+
 const WaitingRoom = styled.div`
   align-items: center;
   display: flex;
+  flex-direction: column;
   font-size: 36px;
   justify-content: center;
   min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);

--- a/app/src/views/Market/Market.tsx
+++ b/app/src/views/Market/Market.tsx
@@ -105,7 +105,7 @@ const Market: React.FC = () => {
                 )
               ) : (
                 <WaitingRoom>
-                  <Button text="Unlock wallet" onClick={handleUnlock} />{' '}
+                  <Button text="Connect Wallet" onClick={handleUnlock} />{' '}
                 </WaitingRoom>
               )}
             </StyledMarket>

--- a/app/src/views/Market/components/OptionsTable/OptionsTable.tsx
+++ b/app/src/views/Market/components/OptionsTable/OptionsTable.tsx
@@ -11,11 +11,11 @@ import { formatAddress } from '../../../../utils'
 
 import Button from 'components/Button'
 import EmptyTable from '../EmptyTable'
-import LitContainer from '../../../../components/LitContainer'
-import Table from '../../../../components/Table'
-import TableBody from '../../../../components/TableBody'
-import TableCell from '../../../../components/TableCell'
-import TableRow from '../../../../components/TableRow'
+import LitContainer from 'components/LitContainer'
+import Table from 'components/Table'
+import TableBody from 'components/TableBody'
+import TableCell from 'components/TableCell'
+import TableRow from 'components/TableRow'
 
 export type FormattedOption = {
   breakEven: number

--- a/app/src/views/Market/components/OrderCard/components/BuyOrMint/BuyOrMint.tsx
+++ b/app/src/views/Market/components/OrderCard/components/BuyOrMint/BuyOrMint.tsx
@@ -21,9 +21,7 @@ const BuyOrMint: React.FC = () => {
     setBuyCard(!buyCard)
   }, [buyCard, setBuyCard])
 
-  const { asset, month, day, type, strike } = destructureOptionSymbol(
-    item.id
-  )
+  const { asset, month, day, type, strike } = destructureOptionSymbol(item.id)
 
   const title = useMemo(() => {
     if (buyCard) {
@@ -39,10 +37,10 @@ const BuyOrMint: React.FC = () => {
   return (
     <Card border>
       <CardContent>
-      <StyledTitle>{title}</StyledTitle>
+        <StyledTitle>{title}</StyledTitle>
         <Toggle>
           <ToggleButton active={buyCard} onClick={handleToggle} text="Buy" />
-          <ToggleButton active={!buyCard} onClick={handleToggle} text="Mint + Sell" />
+          <ToggleButton active={!buyCard} onClick={handleToggle} text="Mint" />
         </Toggle>
         {buyCard ? <Buy /> : <Mint />}
       </CardContent>

--- a/app/src/views/Market/components/OrderCard/components/BuyOrMint/components/Buy.tsx
+++ b/app/src/views/Market/components/OrderCard/components/BuyOrMint/components/Buy.tsx
@@ -9,11 +9,17 @@ import Label from 'components/Label'
 import Spacer from 'components/Spacer'
 
 import useOrders from 'hooks/useOrders'
+import useTokenBalance from 'hooks/useTokenBalance'
+
+import formatBalance from '../../../../../../../utils/formatBalance'
 
 const Buy: React.FC = () => {
   const { buyOptions, item } = useOrders()
   const [quantity, setQuantity] = useState('')
   const { library } = useWeb3React()
+
+  const stablecoinAddress = '0xb05cB19b19e09c4c7b72EA929C8CfA3187900Ad2' // Fix - should not be hardcode
+  const tokenBalance = useTokenBalance(stablecoinAddress)
 
   const handleBuyClick = useCallback(() => {
     buyOptions(library, item?.address, Number(quantity))
@@ -58,7 +64,7 @@ const Buy: React.FC = () => {
       <Spacer />
       <Box row justifyContent="space-between">
         <Label text="Buying Power" />
-        <span>${buyingPower.toFixed(2)}</span>
+        <span>${formatBalance(tokenBalance)}</span>
       </Box>
       <Spacer />
       <Box row justifyContent="space-between">

--- a/app/src/views/Market/components/OrderCard/components/BuyOrMint/components/Mint.tsx
+++ b/app/src/views/Market/components/OrderCard/components/BuyOrMint/components/Mint.tsx
@@ -9,11 +9,17 @@ import Label from 'components/Label'
 import Spacer from 'components/Spacer'
 
 import useOrders from 'hooks/useOrders'
+import useTokenBalance from 'hooks/useTokenBalance'
+
+import formatBalance from '../../../../../../../utils/formatBalance'
 
 const Mint: React.FC = () => {
   const { mintOptions, item } = useOrders()
   const [quantity, setQuantity] = useState('')
   const { library } = useWeb3React()
+
+  const testEthAddress = '0xc45c339313533a6c9B05184CD8B5486BC53F75Fb' // Fix - should not be hardcode
+  const tokenBalance = useTokenBalance(testEthAddress)
 
   const handleMintClick = useCallback(() => {
     mintOptions(library, item?.address, Number(quantity))
@@ -31,11 +37,9 @@ const Mint: React.FC = () => {
     [setQuantity]
   )
 
-  let purchasePower = 100000
-
   const handleSetMax = () => {
     let max =
-      Math.round((purchasePower / +item.price + Number.EPSILON) * 100) / 100
+      Math.round((+tokenBalance / +item.price + Number.EPSILON) * 100) / 100
     setQuantity(max.toString())
   }
 
@@ -55,6 +59,11 @@ const Mint: React.FC = () => {
         value={`${quantity}`}
         endAdornment={<Button size="sm" text="Max" onClick={handleSetMax} />}
       />
+      <Spacer />
+      <Box row justifyContent="space-between">
+        <Label text="Minting Power" />
+        <span>{formatBalance(tokenBalance)} ETH</span>
+      </Box>
       <Spacer />
       <Box row justifyContent="space-between">
         <Label text="Total Credit" />

--- a/app/src/views/Market/components/OrderCard/components/EmptyOrder/EmptyOrder.tsx
+++ b/app/src/views/Market/components/OrderCard/components/EmptyOrder/EmptyOrder.tsx
@@ -7,8 +7,6 @@ import Card from 'components/Card'
 import CardContent from 'components/CardContent'
 import CardTitle from 'components/CardTitle'
 
-import Available from '../Available'
-
 const EmptyOrder: React.FC = () => (
   <Card>
     <CardTitle>Your order</CardTitle>
@@ -18,9 +16,8 @@ const EmptyOrder: React.FC = () => (
           <AddIcon />
         </StyledEmptyIcon>
         <StyledEmptyMessage>
-          Click the select button next to the options to add to your order.
+          Click the open button next to the options to trade.
         </StyledEmptyMessage>
-        <Available>$250,000 Buying Power</Available>
       </StyledEmptyContent>
     </CardContent>
   </Card>

--- a/app/src/views/Market/components/OrderCard/components/SellOrExercise/components/Exercise.tsx
+++ b/app/src/views/Market/components/OrderCard/components/SellOrExercise/components/Exercise.tsx
@@ -9,11 +9,17 @@ import Label from 'components/Label'
 import Spacer from 'components/Spacer'
 
 import useOrders from 'hooks/useOrders'
+import useTokenBalance from 'hooks/useTokenBalance'
+
+import formatBalance from '../../../../../../../utils/formatBalance'
 
 const Exercise: React.FC = () => {
   const { exerciseOptions, item } = useOrders()
   const [quantity, setQuantity] = useState('')
   const { library } = useWeb3React()
+
+  const tokenAddress = item.address
+  const tokenBalance = useTokenBalance(tokenAddress)
 
   const handleExerciseClick = useCallback(() => {
     exerciseOptions(library, item?.address, Number(quantity))
@@ -31,11 +37,9 @@ const Exercise: React.FC = () => {
     [setQuantity]
   )
 
-  let purchasePower = 100000
-
   const handleSetMax = () => {
     let max =
-      Math.round((purchasePower / +item.price + Number.EPSILON) * 100) / 100
+      Math.round((+tokenBalance / +item.price + Number.EPSILON) * 100) / 100
     setQuantity(max.toString())
   }
 
@@ -55,6 +59,14 @@ const Exercise: React.FC = () => {
         value={`${quantity}`}
         endAdornment={<Button size="sm" text="Max" onClick={handleSetMax} />}
       />
+      <Spacer />
+      <Box row justifyContent="space-between">
+        <Label text="Exercising Power" />
+        <span>
+          {formatBalance(tokenBalance)}{' '}
+          <span style={{ fontSize: '11px' }}>Options</span>
+        </span>
+      </Box>
       <Spacer />
       <Box row justifyContent="space-between">
         <Label text="Total Cost" />

--- a/app/src/views/Market/components/OrderCard/components/SellOrExercise/components/Exercise.tsx
+++ b/app/src/views/Market/components/OrderCard/components/SellOrExercise/components/Exercise.tsx
@@ -21,6 +21,9 @@ const Exercise: React.FC = () => {
   const tokenAddress = item.address
   const tokenBalance = useTokenBalance(tokenAddress)
 
+  const stablecoinAddress = '0xb05cB19b19e09c4c7b72EA929C8CfA3187900Ad2' // Fix - should not be hardcode
+  const stablecoinBalance = useTokenBalance(stablecoinAddress)
+
   const handleExerciseClick = useCallback(() => {
     exerciseOptions(library, item?.address, Number(quantity))
   }, [exerciseOptions, item, library, quantity])
@@ -66,6 +69,11 @@ const Exercise: React.FC = () => {
           {formatBalance(tokenBalance)}{' '}
           <span style={{ fontSize: '11px' }}>Options</span>
         </span>
+      </Box>
+      <Spacer />
+      <Box row justifyContent="space-between">
+        <Label text="Buying Power" />
+        <span>${formatBalance(stablecoinBalance)} </span>
       </Box>
       <Spacer />
       <Box row justifyContent="space-between">

--- a/app/src/views/Market/components/OrderCard/components/SellOrExercise/components/Sell.tsx
+++ b/app/src/views/Market/components/OrderCard/components/SellOrExercise/components/Sell.tsx
@@ -9,11 +9,21 @@ import Label from 'components/Label'
 import Spacer from 'components/Spacer'
 
 import useOrders from 'hooks/useOrders'
+import useTokenBalance from 'hooks/useTokenBalance'
+
+import formatBalance from '../../../../../../../utils/formatBalance'
 
 const Sell: React.FC = () => {
   const { sellOptions, item } = useOrders()
   const [quantity, setQuantity] = useState('')
   const { library } = useWeb3React()
+
+  const testEthAddress = '0xc45c339313533a6c9B05184CD8B5486BC53F75Fb' // Fix - should not be hardcode
+  const stablecoinAddress = '0xb05cB19b19e09c4c7b72EA929C8CfA3187900Ad2' // Fix - should not be hardcode
+  // Conditionally show the selling power according to the collateral for each type, put or call.
+  const tokenAddress =
+    item.id.substring(11, 12) === 'C' ? testEthAddress : stablecoinAddress
+  const tokenBalance = useTokenBalance(tokenAddress)
 
   const handleSellClick = useCallback(() => {
     sellOptions(library, item?.address, Number(quantity))
@@ -31,11 +41,9 @@ const Sell: React.FC = () => {
     [setQuantity]
   )
 
-  const buyingPower = 250000
-
   const handleSetMax = () => {
     let max =
-      Math.round((buyingPower / +item.price + Number.EPSILON) * 100) / 100
+      Math.round((+tokenBalance / +item.price + Number.EPSILON) * 100) / 100
     setQuantity(max.toString())
   }
 
@@ -57,8 +65,8 @@ const Sell: React.FC = () => {
       />
       <Spacer />
       <Box row justifyContent="space-between">
-        <Label text="Buying Power" />
-        <span>${buyingPower.toFixed(2)}</span>
+        <Label text="Selling Power" />
+        <span>{formatBalance(tokenBalance)} ETH</span>
       </Box>
       <Spacer />
       <Box row justifyContent="space-between">

--- a/app/src/views/Market/components/PositionsTable/PositionsTable.tsx
+++ b/app/src/views/Market/components/PositionsTable/PositionsTable.tsx
@@ -10,15 +10,15 @@ import { useWeb3React } from '@web3-react/core'
 import { OrderItem } from '../../../../contexts/Order/types'
 import { destructureOptionSymbol } from 'lib/utils'
 
-import Timer from '../Timer'
-import EmptyTable from '../EmptyTable'
 import Button from 'components/Button'
+import EmptyTable from '../EmptyTable'
+import FilledBar from '../FilledBar'
 import LitContainer from 'components/LitContainer'
 import Table from 'components/Table'
 import TableBody from 'components/TableBody'
 import TableCell from 'components/TableCell'
 import TableRow from 'components/TableRow'
-import FilledBar from '../FilledBar'
+import Timer from '../Timer'
 
 export type FormattedOption = {
   breakEven: number

--- a/app/src/views/Market/components/TestnetCard/TestnetCard.tsx
+++ b/app/src/views/Market/components/TestnetCard/TestnetCard.tsx
@@ -37,7 +37,7 @@ const TestnetCard: React.FC<TestnetCardProps> = () => {
           <StyledTitle>
             Earn NFT Rewards
             <Button
-              href="https://blog.primitive.finance"
+              href="https://primitive.finance/beta"
               variant="transparent"
               text="Learn more"
               size="sm"
@@ -46,7 +46,7 @@ const TestnetCard: React.FC<TestnetCardProps> = () => {
               <LaunchIcon fontSize="small" />
             </Button>
           </StyledTitle>
-          Click the select button next to the options to add to your order.
+          Click the open button next to the options to trade.
           <Spacer />
           <StyledTitle>1.</StyledTitle>
           <Button
@@ -58,7 +58,7 @@ const TestnetCard: React.FC<TestnetCardProps> = () => {
           <StyledTitle>2.</StyledTitle>
           <Button
             onClick={handleMintTestTokens}
-            text={'Give Feedback'}
+            text={'Make a Trade'}
             variant="default"
             disabled
           />
@@ -66,7 +66,7 @@ const TestnetCard: React.FC<TestnetCardProps> = () => {
           <StyledTitle>3.</StyledTitle>
           <Button
             onClick={handleMintTestTokens}
-            text={'Claim NFT'}
+            text={'Claim NFT Reward'}
             variant="default"
             disabled
           />

--- a/app/src/views/Markets/Markets.tsx
+++ b/app/src/views/Markets/Markets.tsx
@@ -119,8 +119,8 @@ const Markets: React.FC = () => {
         <Route exact path={path}>
           <PageHeader
             icon={days[day]}
-            subtitle="Oracle-less options."
-            title="Select an option market."
+            title="Choose an option market."
+            subtitle="View available options and trade."
           />
           <MarketCards />
         </Route>

--- a/app/src/views/Markets/components/MarketCards.tsx
+++ b/app/src/views/Markets/components/MarketCards.tsx
@@ -68,7 +68,7 @@ const MarketCard: React.FC<MarketCardProps> = ({ market }) => {
             <Button
               disabled={!poolActive}
               full
-              text="Select"
+              text="Continue"
               to={`/markets/${market.id}`}
             />
           </StyledContent>

--- a/website/src/components/Button/Button.tsx
+++ b/website/src/components/Button/Button.tsx
@@ -89,8 +89,8 @@ const Button: React.FC<ButtonProps> = ({
       background = colors.white
       buttonColor = colors.black
       border = ''
-      hoverBackgroundColor = colors.white
-      hoverColor = colors.black
+      hoverBackgroundColor = colors.black
+      hoverColor = colors.white
   }
 
   const ButtonChild = useMemo(() => {

--- a/website/src/components/Button/Button.tsx
+++ b/website/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
+import { Link } from 'gatsby'
 import { ThemeContext } from 'react-neu'
 
 export interface ButtonProps {

--- a/website/src/components/H1/H1.tsx
+++ b/website/src/components/H1/H1.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const H1: React.FC = ({ children }) => {
+  return <StyledSectionTitle>{children}</StyledSectionTitle>
+}
+
+const StyledSectionTitle = styled.div`
+  color: ${props => props.theme.textColor};
+  font-size: 36px;
+  font-weight: 700;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+  @media (max-width: 768px) {
+    text-align: left;
+  }
+`
+
+export default H1

--- a/website/src/components/H1/index.ts
+++ b/website/src/components/H1/index.ts
@@ -1,0 +1,2 @@
+import H1 from './H1'
+export { H1 as default }

--- a/website/src/components/PageHeader/PageHeader.tsx
+++ b/website/src/components/PageHeader/PageHeader.tsx
@@ -59,7 +59,7 @@ const StyledTitle = styled.h1`
 const StyledSubtitle = styled.h1`
   color: ${props => props.theme.textColor};
   font-size: 18px;
-  font-weight: 400;
+  font-weight: 500;
   margin: 0;
   opacity: 0.66;
   padding: 0;

--- a/website/src/components/PageHeader/PageHeader.tsx
+++ b/website/src/components/PageHeader/PageHeader.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import styled from 'styled-components'
 import { Container, Spacer } from 'react-neu'
 
+import H1 from 'components/H1'
+import Subtitle from 'components/Subtitle'
+
 interface PageHeaderProps {
   icon: React.ReactNode
   subtitle?: string
@@ -13,9 +16,9 @@ const PageHeader: React.FC<PageHeaderProps> = ({ icon, subtitle, title }) => {
     <Container>
       <StyledPageHeader>
         <StyledIcon>{icon}</StyledIcon>
-        <StyledTitle>{title}</StyledTitle>
+        <H1>{title}</H1>
         <Spacer />
-        <StyledSubtitle>{subtitle}</StyledSubtitle>
+        <Subtitle>{subtitle}</Subtitle>
       </StyledPageHeader>
     </Container>
   )
@@ -42,31 +45,6 @@ const StyledPageHeader = styled.div`
   flex-direction: column;
   padding-bottom: ${props => props.theme.spacing[6]}px;
   margin: 0 auto;
-`
-
-const StyledTitle = styled.h1`
-  color: ${props => props.theme.textColor};
-  font-size: 36px;
-  font-weight: 700;
-  margin: 0;
-  padding: 0;
-  text-align: center;
-  @media (max-width: 768px) {
-    text-align: left;
-  }
-`
-
-const StyledSubtitle = styled.h1`
-  color: ${props => props.theme.textColor};
-  font-size: 18px;
-  font-weight: 500;
-  margin: 0;
-  opacity: 0.66;
-  padding: 0;
-  text-align: center;
-  @media (max-width: 768px) {
-    text-align: left;
-  }
 `
 
 export default PageHeader

--- a/website/src/components/Subtitle/Subtitle.tsx
+++ b/website/src/components/Subtitle/Subtitle.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Subtitle: React.FC = ({ children }) => {
+  return <StyledSubtitle>{children}</StyledSubtitle>
+}
+
+const StyledSubtitle = styled.h1`
+  color: ${props => props.theme.textColor};
+  font-size: 18px;
+  font-weight: 500;
+  margin: 0;
+  opacity: 0.66;
+  padding: 0;
+  text-align: center;
+  @media (max-width: 768px) {
+    text-align: left;
+  }
+`
+
+export default Subtitle

--- a/website/src/components/Subtitle/index.ts
+++ b/website/src/components/Subtitle/index.ts
@@ -1,0 +1,2 @@
+import Subtitle from './Subtitle'
+export { Subtitle as default }

--- a/website/src/components/TopBar/TopBar.tsx
+++ b/website/src/components/TopBar/TopBar.tsx
@@ -12,6 +12,11 @@ const TopBar: React.FC = () => {
         <Box flex={1} />
         <Box alignItems="center" row>
           <Button
+            text="Discord"
+            variant="transparent"
+            href="https://discord.gg/JBM6APT"
+          />
+          <Button
             href="https://docs.primitive.finance"
             size="md"
             text="Docs"

--- a/website/src/components/TopBar/TopBar.tsx
+++ b/website/src/components/TopBar/TopBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import { Box, Container, Spacer } from 'react-neu'
+
 import Button from 'components/Button'
 import Logo from 'components/Logo'
 

--- a/website/src/pages/beta.tsx
+++ b/website/src/pages/beta.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
+import { Link } from 'gatsby'
 import { createTheme, ThemeProvider } from 'react-neu'
 
 import TopBar from 'components/TopBar'
-import Home from 'views/Home'
+import Beta from 'views/Beta'
 
 export default function Index() {
   const { dark, light } = createTheme({
@@ -12,7 +13,7 @@ export default function Index() {
   return (
     <ThemeProvider darkTheme={dark} lightTheme={light}>
       <TopBar />
-      <Home />
+      <Beta />
     </ThemeProvider>
   )
 }

--- a/website/src/views/Beta/Beta.tsx
+++ b/website/src/views/Beta/Beta.tsx
@@ -3,54 +3,28 @@ import styled from 'styled-components'
 
 import Button from 'components/Button'
 import H1 from 'components/H1'
+import Subtitle from 'components/Subtitle'
 import Page from 'components/Page'
 import PageHeader from 'components/PageHeader'
-import Subtitle from 'components/Subtitle'
 import { Container, Box, Spacer, Separator } from 'react-neu'
 
-import Leaf from './assets/greek-leaf.png'
-
-const Home: React.FC = () => {
+const Beta: React.FC = () => {
   return (
     <Page>
       <StyledHero>
         <PageHeader
           icon={''}
-          title="Options for a permissionless future."
-          subtitle="Decentralized, open, and easy."
+          title="The Open Beta is an 8-week event starting in October."
+          subtitle="Trading on the supported networks makes you eligible for non-monetary NFT rewards. 
+          The available rewards and event guide will be posted on the Primitive discord
+          first, then updated on this page."
         />
         <Container size="lg">
           <Box row justifyContent="center">
-            <Button text="Start Trading" href="https://app.primitive.finance" />
+            <Button text="Join the Discord" href="https://discord.gg/JBM6APT" />
           </Box>
         </Container>
       </StyledHero>
-      <Container size="lg">
-        <StyledSectionInformation>Learn more below.</StyledSectionInformation>
-        <Spacer size="lg" />
-        <Separator />
-        <Spacer size="lg" />
-        <IconContainer>
-          <StyledIcon>
-            <img src={Leaf} height="124px" alt="vines" />
-          </StyledIcon>
-        </IconContainer>
-        <Spacer size="md" />
-        <H1>A protocol built on Ethereum for decentralized options.</H1>
-        <Spacer size="md" />
-        <Subtitle>No admin keys.</Subtitle>
-        <Spacer size="md" />
-        <Subtitle>No oracles.</Subtitle>
-        <Spacer size="md" />
-        <Subtitle>No signup.</Subtitle>
-        <Spacer size="md" />
-        <Subtitle>No whitelist.</Subtitle>
-        <Spacer size="lg" />
-        <IconContainer>
-          <Button to="beta" text="Join the Open Beta" />
-        </IconContainer>
-        <Spacer size="lg" />
-      </Container>
     </Page>
   )
 }
@@ -94,4 +68,4 @@ const StyledSectionInformation = styled.div`
   text-align: center;
 `
 
-export default Home
+export default Beta

--- a/website/src/views/Beta/Beta.tsx
+++ b/website/src/views/Beta/Beta.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Container, Box } from 'react-neu'
 
 import Button from 'components/Button'
-import H1 from 'components/H1'
-import Subtitle from 'components/Subtitle'
 import Page from 'components/Page'
 import PageHeader from 'components/PageHeader'
-import { Container, Box, Spacer, Separator } from 'react-neu'
 
 const Beta: React.FC = () => {
   return (
@@ -37,35 +35,6 @@ const StyledHero = styled.div`
   height: calc(80vh - 96px);
   max-height: 600px;
   min-height: 400px;
-`
-
-const IconContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`
-
-const StyledIcon = styled.span.attrs({
-  role: 'img',
-})`
-  font-size: 96px;
-  min-height: 96px;
-  line-height: 96px;
-  text-align: center;
-  min-width: 96px;
-  @media (max-width: 768px) {
-    font-size: 64px;
-    text-align: left;
-  }
-`
-
-const StyledSectionInformation = styled.div`
-  color: ${props => props.theme.colors.black};
-  font-size: 14px;
-  font-weight: 500;
-  opacity: 0.5;
-  margin: 0;
-  padding: 0;
-  text-align: center;
 `
 
 export default Beta

--- a/website/src/views/Beta/index.ts
+++ b/website/src/views/Beta/index.ts
@@ -1,0 +1,2 @@
+import Beta from './Beta'
+export { Beta as default }

--- a/website/src/views/Home/Home.tsx
+++ b/website/src/views/Home/Home.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Container, Box, Spacer, Separator } from 'react-neu'
 
 import Button from 'components/Button'
 import H1 from 'components/H1'
 import Page from 'components/Page'
 import PageHeader from 'components/PageHeader'
 import Subtitle from 'components/Subtitle'
-import { Container, Box, Spacer, Separator } from 'react-neu'
 
 import Leaf from './assets/greek-leaf.png'
 

--- a/website/src/views/Home/Home.tsx
+++ b/website/src/views/Home/Home.tsx
@@ -19,17 +19,12 @@ const Home: React.FC = () => {
         />
         <Container size="lg">
           <Box row justifyContent="center">
-            <Button text="App" href="https://app.primitive.finance" />
-            <Spacer />
-            <Button
-              text="Join the Discord"
-              variant="secondary"
-              href="https://discord.gg/JBM6APT"
-            />
+            <Button text="Start Trading" href="https://app.primitive.finance" />
           </Box>
         </Container>
       </StyledHero>
       <Container size="lg">
+        <StyledSectionInformation>Learn more below.</StyledSectionInformation>
         <Spacer size="lg" />
         <Separator />
         <Spacer size="lg" />
@@ -37,16 +32,20 @@ const Home: React.FC = () => {
           <img src={Leaf} height="124px" alt="vines" />
         </IconContainer>
         <Spacer size="md" />
-        <StyledSectionTitle>Physically settled options.</StyledSectionTitle>
+        <StyledSectionTitle>
+          A protocol built on Ethereum for decentralized options.
+        </StyledSectionTitle>
         <Spacer size="md" />
         <StyledSectionSubtitle>No admin keys.</StyledSectionSubtitle>
         <Spacer size="md" />
         <StyledSectionSubtitle>No oracles.</StyledSectionSubtitle>
         <Spacer size="md" />
-        <StyledSectionSubtitle>No whitelist.</StyledSectionSubtitle>
+        <StyledSectionSubtitle>No signup.</StyledSectionSubtitle>
         <Spacer size="md" />
+        <StyledSectionSubtitle>No whitelist.</StyledSectionSubtitle>
+        <Spacer size="lg" />
         <IconContainer>
-          <Button text="Sign up for the Beta" />
+          <Button text="Join the Open Beta" />
         </IconContainer>
         <Spacer size="lg" />
       </Container>
@@ -81,8 +80,18 @@ const StyledSectionTitle = styled.div`
 const StyledSectionSubtitle = styled.div`
   color: ${props => props.theme.colors.black};
   font-size: 24px;
-  font-weight: 700;
-  opacity: 0.75;
+  font-weight: 500;
+  opacity: 0.66;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+`
+
+const StyledSectionInformation = styled.div`
+  color: ${props => props.theme.colors.black};
+  font-size: 14px;
+  font-weight: 500;
+  opacity: 0.5;
   margin: 0;
   padding: 0;
   text-align: center;


### PR DESCRIPTION
## Description

Website:
- Changes App -> Start Trading and make it the primary button.
- Moves Join Discord to the navbar.
- Adds a Beta page at `/beta` which will need to be updated with appropriate info.
- Hovering over primary buttons will now flip the colors so they are more animated

App:
- Fixed web3 error related to the Uniswap SDK using an ethers default provider which was throwing errors. Replaced default provider with connected provider.
- Gave more context around what each button does, improved the wording on all components.
- Added a useTokenBalance hook to get the actual buying/purchasing/minting/exercising power a user has.
- Learn more link in Testnet card now redirects to https://primitive.finance/beta
- Unlock Wallet -> Connect Wallet
- When a user is asked to connect to their wallet, if they are unfamiliar with it, there is a link to ethereum.org/en/wallets which explains the topic. 
- Added proper comma formatting to numbers in the order card
