### PR TITLE
Feature/default options

### DIFF
--- a/app/src/components/Footer/Footer.tsx
+++ b/app/src/components/Footer/Footer.tsx
@@ -31,6 +31,7 @@ const StyledContainer = styled.div`
   position: fixed;
   bottom: -1em;
   width: 100%;
+  pointer-events: none;
 `
 
 const Loader = styled.div`
@@ -57,6 +58,7 @@ const StyledFooter = styled.footer`
   padding-left: 1em;
   padding-right: 2em;
   justify-content: space-between;
+  pointer-events: none;
 `
 const StyledFooterInner = styled.div`
   align-items: center;

--- a/app/src/components/Footer/Footer.tsx
+++ b/app/src/components/Footer/Footer.tsx
@@ -46,11 +46,12 @@ const Loader = styled.div`
 const StyledBlockNumber = styled.h5`
   align-items: center;
   background-color: ${(props) => props.theme.color.grey[800]};
-  padding: 10px;
+  padding: 4px;
   opacity: 90%;
   border-radius: 10px;
   color: ${(props) => props.theme.color.white};
   display: flex;
+  max-height: 0.1em;
   margin-right: ${(props) => props.theme.spacing[4]}px;
   padding: ${(props) => props.theme.spacing[4]}px;
 `
@@ -66,7 +67,7 @@ const StyledFooter = styled.footer`
 const StyledFooterInner = styled.div`
   align-items: center;
   display: flex;
-  height: ${(props) => props.theme.barHeight}px;
+  height: 2em;
   justify-content: center;
   max-width: ${(props) => props.theme.siteWidth}px;
   margin-right: ${(props) => props.theme.spacing[4]}px;

--- a/app/src/components/Footer/Footer.tsx
+++ b/app/src/components/Footer/Footer.tsx
@@ -7,15 +7,17 @@ import Nav from './components/Nav'
 const Footer: React.FC = () => {
   const { data } = useBlockNumber()
   return (
-    <StyledFooter>
-      <StyledFooterInner>
-        <Nav />
-      </StyledFooterInner>
-      <StyledBlockNumber>
-        {data}
-        <Loader />
-      </StyledBlockNumber>
-    </StyledFooter>
+    <StyledContainer>
+      <StyledFooter>
+        <StyledFooterInner>
+          <Nav />
+        </StyledFooterInner>
+        <StyledBlockNumber>
+          {data}
+          <Loader />
+        </StyledBlockNumber>
+      </StyledFooter>
+    </StyledContainer>
   )
 }
 
@@ -24,6 +26,13 @@ const breathe = keyframes`
   50% {opacity: 1; }
   100% { opacity: .5;}
 ;`
+
+const StyledContainer = styled.div`
+  position: fixed;
+  bottom: -1em;
+  width: 100%;
+`
+
 const Loader = styled.div`
   border-radius: 50%;
   width: 10px;
@@ -36,11 +45,14 @@ const Loader = styled.div`
 const StyledBlockNumber = styled.h5`
   display: flex;
   align-items: center;
+  background-color: ${(props) => props.theme.color.grey[800]};
+  padding: 10px;
+  opacity: 90%;
+  border-radius: 10px;
   color: ${(props) => props.theme.color.white};
 `
 const StyledFooter = styled.footer`
   align-items: center;
-  bottom: 1em;
   display: flex;
   padding-left: 1em;
   padding-right: 2em;
@@ -50,9 +62,7 @@ const StyledFooterInner = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
-  height: ${(props) => props.theme.topBarSize}px;
   max-width: ${(props) => props.theme.siteWidth}px;
-
   margin-right: ${(props) => props.theme.spacing[4]}px;
   padding: ${(props) => props.theme.spacing[4]}px;
 `

--- a/app/src/components/Footer/components/Nav.tsx
+++ b/app/src/components/Footer/components/Nav.tsx
@@ -42,6 +42,7 @@ const StyledNav = styled.nav`
   background-color: ${(props) => props.theme.color.grey[800]};
   border-radius: 10px;
   opacity: 90%;
+  pointer-events: all;
 `
 
 const StyledLink = styled.a`

--- a/app/src/components/Footer/components/Nav.tsx
+++ b/app/src/components/Footer/components/Nav.tsx
@@ -39,6 +39,9 @@ const Nav: React.FC = () => {
 
 const StyledNav = styled.nav`
   display: flex;
+  background-color: ${(props) => props.theme.color.grey[800]};
+  border-radius: 10px;
+  opacity: 90%;
 `
 
 const StyledLink = styled.a`

--- a/app/src/components/Market/FilterBar/FilterBar.tsx
+++ b/app/src/components/Market/FilterBar/FilterBar.tsx
@@ -8,16 +8,21 @@ import Spacer from '@/components/Spacer'
 
 export interface FilterBarProps {
   active: boolean
-  setCallActive: Function
+  setCallActive: any
+  expiry: number
+  setExpiry: any
 }
 
 const FilterBar: React.FC<FilterBarProps> = (props) => {
-  const { active, setCallActive } = props
+  const { active, setCallActive, expiry, setExpiry } = props
 
   const handleToggleClick = useCallback(() => {
     setCallActive(!active)
   }, [active, setCallActive])
 
+  const handleFilter = (event: any) => {
+    setExpiry(event.target.value)
+  }
   return (
     <StyledFilterBar>
       <LitContainer>
@@ -35,8 +40,8 @@ const FilterBar: React.FC<FilterBarProps> = (props) => {
             />
           </Toggle>
           <Spacer size="lg" />
-          <StyledSelect>
-            <StyledOption>November 2</StyledOption>
+          <StyledSelect value={expiry} onChange={handleFilter}>
+            <StyledOption>December 30 2020</StyledOption>
           </StyledSelect>
         </StyledFilterBarInner>
       </LitContainer>

--- a/app/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -29,6 +29,7 @@ export type FormattedOption = {
 
 export interface OptionsTableProps {
   options: FormattedOption[]
+  optionExp: number
   asset: string
   callActive: boolean
 }
@@ -37,7 +38,7 @@ const ETHERSCAN_MAINNET = 'https://etherscan.io/address'
 const ETHERSCAN_RINKEBY = 'https://rinkeby.etherscan.io/address'
 
 const OptionsTable: React.FC<OptionsTableProps> = (props) => {
-  const { callActive, asset } = props
+  const { callActive, asset, optionExp } = props
   const { options, getOptions } = useOptions()
   const { onAddItem, item } = useOrders()
   const { library, chainId } = useWeb3React()
@@ -72,7 +73,15 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
         {options[type].length > 1 ? (
           <TableBody>
             {options[type].map((option) => {
-              const { breakEven, price, strike, address, isActive } = option
+              const {
+                breakEven,
+                price,
+                strike,
+                address,
+                isActive,
+                expiry,
+              } = option
+              if (optionExp != expiry && expiry !== 0) return null
               if (!isActive) {
                 return (
                   <TableRow

--- a/app/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -39,7 +39,7 @@ const ETHERSCAN_RINKEBY = 'https://rinkeby.etherscan.io/address'
 const OptionsTable: React.FC<OptionsTableProps> = (props) => {
   const { callActive, asset } = props
   const { options, getOptions } = useOptions()
-  const { onAddItem } = useOrders()
+  const { onAddItem, item } = useOrders()
   const { library, chainId } = useWeb3React()
 
   useEffect(() => {
@@ -72,7 +72,25 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
         {options[type].length > 1 ? (
           <TableBody>
             {options[type].map((option) => {
-              const { breakEven, price, strike, address } = option
+              const { breakEven, price, strike, address, isActive } = option
+              if (!isActive) {
+                return (
+                  <TableRow
+                    key={strike}
+                    onClick={() => {
+                      onAddItem(option, 'BUY')
+                    }}
+                  >
+                    <TableCell key={strike}>${formatBalance(strike)}</TableCell>
+                    <TableCell key={breakEven}>---</TableCell>
+                    <TableCell key={price}>---</TableCell>
+                    <TableCell key={address}>---</TableCell>
+                    <StyledButtonCell key={'Open'}>
+                      <ArrowForwardIosIcon />
+                    </StyledButtonCell>
+                  </TableRow>
+                )
+              }
               return (
                 <TableRow
                   key={address}

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -116,6 +116,10 @@ export const DAI = new Token(
   'Dai Stablecoin'
 )
 
+export const DEFAULT_STRIKE_LOW = 0.9
+export const DEFAULT_STRIKE_MID = 1.0
+export const DEFAULT_STRIKE_HIGH = 1.1
+
 export const CURRENT_VERSION = 1.0
 export const NO_VERSION = -1
 export const DEFAULT_DEADLINE = 60 * 20

--- a/app/src/contexts/Options/Options.tsx
+++ b/app/src/contexts/Options/Options.tsx
@@ -95,7 +95,6 @@ const Options: React.FC = (props) => {
       // Asset address and quantity of options
       const assetAddress = AssetAddresses[assetName][chainId]
       const optionsLength = Object.keys(OptionDeployments).length
-
       // Objects and arrays to populate
       const optionsObject = {
         calls: [EmptyAttributes],
@@ -165,9 +164,42 @@ const Options: React.FC = (props) => {
           address: address,
           id: id,
           expiry: expiry,
+          isActive: true,
         })
       }
 
+      if (calls.length < 4) {
+        calls.push({
+          breakEven: 0,
+          change: 0,
+          price: 0,
+          strike: 350,
+          volume: 0,
+          address: '',
+          id: '',
+          expiry: 0,
+          isActive: false,
+        })
+      }
+      calls.sort((a, b) => {
+        return a.strike - b.strike
+      })
+      if (puts.length < 4) {
+        puts.push({
+          breakEven: 0,
+          change: 0,
+          price: 0,
+          strike: 350,
+          volume: 0,
+          address: '',
+          id: '',
+          expiry: 0,
+          isActive: false,
+        })
+      }
+      puts.sort((a, b) => {
+        return a.strike - b.strike
+      })
       // Get the final options object and dispatch it to set its state for the hook.
       Object.assign(optionsObject, {
         calls: calls,

--- a/app/src/contexts/Options/Options.tsx
+++ b/app/src/contexts/Options/Options.tsx
@@ -95,6 +95,11 @@ const Options: React.FC = (props) => {
       // Asset address and quantity of options
       const assetAddress = AssetAddresses[assetName][chainId]
       const optionsLength = Object.keys(OptionDeployments).length
+      const priceData = await fetch(
+        `https://api.coingecko.com/api/v3/simple/price?ids=${assetName}&vs_currencies=usd`
+      )
+      const price = await priceData.json()
+      const spotPrice = Math.ceil(price[assetName].usd / 10) * 10
       // Objects and arrays to populate
       const optionsObject = {
         calls: [EmptyAttributes],
@@ -173,7 +178,7 @@ const Options: React.FC = (props) => {
           breakEven: 0,
           change: 0,
           price: 0,
-          strike: 350,
+          strike: spotPrice,
           volume: 0,
           address: '',
           id: '',
@@ -189,7 +194,7 @@ const Options: React.FC = (props) => {
           breakEven: 0,
           change: 0,
           price: 0,
-          strike: 350,
+          strike: spotPrice,
           volume: 0,
           address: '',
           id: '',

--- a/app/src/contexts/Options/types.ts
+++ b/app/src/contexts/Options/types.ts
@@ -17,6 +17,7 @@ export type OptionsAttributes = {
   address: string
   id: string
   expiry: number
+  isActive: boolean
 }
 
 export const EmptyAttributes = {
@@ -28,6 +29,7 @@ export const EmptyAttributes = {
   address: '',
   id: '',
   expiry: 0,
+  isActive: false,
 }
 
 export interface OptionsState {

--- a/app/src/pages/markets/[id].tsx
+++ b/app/src/pages/markets/[id].tsx
@@ -79,13 +79,15 @@ const Market = ({ market }) => {
   )
 }
 
-const StyledMain = styled.div``
+const StyledMain = styled.div`
+  flex: 0.7;
+`
 
 const StyledMarket = styled.div`
-  width: auto;
-  position: relative;
-  overflow: auto;
   display: flex;
+  flex-direction: row;
+  justify-contet: center;
+  align-items: start;
   width: ${(props) => props.theme.tableWidth}%;
 `
 
@@ -93,6 +95,7 @@ const StyledSideBar = styled.div`
   background: ${(props) => props.theme.color.black};
   border-left: 1px solid ${(props) => props.theme.color.grey[600]};
   box-sizing: border-box;
+  flex: 0.3;
   min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
   padding: ${(props) => props.theme.spacing[4]}px;
   width: ${(props) => props.theme.sidebarWidth}%;

--- a/app/src/pages/markets/[id].tsx
+++ b/app/src/pages/markets/[id].tsx
@@ -34,13 +34,17 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
 
 const Market = ({ market }) => {
   const [callPutActive, setCallPutActive] = useState(true)
+  const [expiry, setExpiry] = useState(1609286400)
   const { chainId, active } = useWeb3React()
   const { marketId } = market
 
-  const handleFilter = () => {
+  const handleFilterType = () => {
     setCallPutActive(!callPutActive)
   }
 
+  const handleFilterExpiry = (exp: number) => {
+    setExpiry(exp)
+  }
   if (!(chainId === 4 || chainId === 1) && active) {
     return <StyledText>Switch to Rinkeby or Mainnet</StyledText>
   }
@@ -50,10 +54,16 @@ const Market = ({ market }) => {
         <StyledMarket>
           <StyledMain>
             <MarketHeader marketId={marketId} />
-            <FilterBar active={callPutActive} setCallActive={handleFilter} />
+            <FilterBar
+              active={callPutActive}
+              setCallActive={handleFilterType}
+              expiry={expiry}
+              setExpiry={handleFilterExpiry}
+            />
             <OptionsTable
               options={mockOptions}
               asset="Ethereum"
+              optionExp={expiry}
               callActive={callPutActive}
             />
           </StyledMain>

--- a/app/src/pages/markets/[id].tsx
+++ b/app/src/pages/markets/[id].tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { GetServerSideProps } from 'next'
 import { useWeb3React } from '@web3-react/core'
 
+import Box from '@/components/Box'
 import Spacer from '@/components/Spacer'
 import OrderProvider from '@/contexts/Order'
 import OptionsProvider from '@/contexts/Options'
@@ -47,23 +48,21 @@ const Market = ({ market }) => {
     <OrderProvider>
       <OptionsProvider>
         <StyledMarket>
-          <>
-            <StyledMain>
-              <MarketHeader marketId={marketId} />
-              <FilterBar active={callPutActive} setCallActive={handleFilter} />
-              <OptionsTable
-                options={mockOptions}
-                asset="Ethereum"
-                callActive={callPutActive}
-              />
-            </StyledMain>
-            <StyledSideBar>
-              <PositionsCard asset="ethereum" />
-              <OrderCard />
-              <Spacer />
-              <TransactionCard />
-            </StyledSideBar>
-          </>
+          <StyledMain>
+            <MarketHeader marketId={marketId} />
+            <FilterBar active={callPutActive} setCallActive={handleFilter} />
+            <OptionsTable
+              options={mockOptions}
+              asset="Ethereum"
+              callActive={callPutActive}
+            />
+          </StyledMain>
+          <StyledSideBar>
+            <PositionsCard asset="ethereum" />
+            <OrderCard />
+            <Spacer />
+            <TransactionCard />
+          </StyledSideBar>
         </StyledMarket>
       </OptionsProvider>
     </OrderProvider>
@@ -73,6 +72,9 @@ const Market = ({ market }) => {
 const StyledMain = styled.div``
 
 const StyledMarket = styled.div`
+  width: auto;
+  position: relative;
+  overflow: auto;
   display: flex;
   width: ${(props) => props.theme.tableWidth}%;
 `


### PR DESCRIPTION
- Added Mock Options to Options context, currently only pushes 1 option at the current spot price strike (estimated by 10$, might not be a great idea for most assets).
- Improved page and footer styling
- Added mock option to option table
- Hooked up expiry filter to options table

TODO: Add mock option / initialize order type