### PR TITLE
Feature/standardize dates

### DIFF
--- a/app/src/components/Market/OrderCard/OrderCard.tsx
+++ b/app/src/components/Market/OrderCard/OrderCard.tsx
@@ -12,6 +12,7 @@ import CardTitle from '@/components/CardTitle'
 import Submit from './components/Submit'
 import OrderOptions from './components/OrderOptions'
 import formatBalance from '@/utils/formatBalance'
+import formatExpiry from '@/utils/formatExpiry'
 import { Operation } from '@/constants/index'
 
 const OrderContent: React.FC = () => {
@@ -31,7 +32,7 @@ const OrderCard: React.FC = () => {
   if (!item.expiry) {
     return null
   }
-  const exp = new Date(parseInt(item.expiry.toString()) * 1000)
+  const { date, month, year } = formatExpiry(item.expiry)
   const clear = () => {
     onRemoveItem(item)
   }
@@ -42,9 +43,7 @@ const OrderCard: React.FC = () => {
           <>
             {`${item.asset} ${
               item.entity.isCall ? 'Call' : 'Put'
-            } $${formatBalance(item.strike)} ${
-              exp.getUTCMonth() + 1
-            }/${exp.getUTCDate()} ${exp.getUTCFullYear()}`}
+            } $${formatBalance(item.strike)} ${month}/${date} ${year}`}
           </>
           <StyledFlex />
           <Button variant="transparent" size="sm" onClick={() => clear()}>

--- a/app/src/components/Market/OrderCard/OrderCard.tsx
+++ b/app/src/components/Market/OrderCard/OrderCard.tsx
@@ -42,9 +42,9 @@ const OrderCard: React.FC = () => {
           <>
             {`${item.asset} ${
               item.entity.isCall ? 'Call' : 'Put'
-            } $${formatBalance(
-              item.strike
-            )} ${exp.getMonth()}/${exp.getDay()} ${exp.getFullYear()}`}
+            } $${formatBalance(item.strike)} ${
+              exp.getUTCMonth() + 1
+            }/${exp.getUTCDate()} ${exp.getUTCFullYear()}`}
           </>
           <StyledFlex />
           <Button variant="transparent" size="sm" onClick={() => clear()}>

--- a/app/src/utils/formatExpiry.ts
+++ b/app/src/utils/formatExpiry.ts
@@ -1,0 +1,10 @@
+import { BigNumberish } from 'ethers'
+const formatExpiry = (unixTimestamp: BigNumberish) => {
+  const unixDate = new Date(parseInt(unixTimestamp.toString()) * 1000)
+  const month = unixDate.getUTCMonth() + 1
+  const date = unixDate.getUTCDate()
+  const year = unixDate.getUTCFullYear()
+  return { date, month, year }
+}
+
+export default formatExpiry


### PR DESCRIPTION
- Adds a formatExpiry fn that takes in a unix timestamp and returns the properly formatted `date` `month` and `year`