### PR TITLE
In multicall functions of Protocol class, the input array data is mad…

### DIFF
--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -274,7 +274,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
             })
             .catch((error) => {
               if (error) {
-                throwError(`Option Registry: ${error.messge}`, '')
+                throwError(`Getting option params: ${error.messge}`, '')
               }
             })
         })


### PR DESCRIPTION
…e into chunks.

Changelog
- Adds chunkArray fn to Protocol class.
- The multicall related functions take an array of addresses. This array size can grow to be very large. So we chunk the array into smaller arrays of length 30. Each smaller array is used in a multicall. This way we avoid the max code size error for large array size inputs.