### PR TITLE
Fixes #131 and #129. Checks if lpPair is null. Converts inputs to wei…

### DIFF
--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -113,13 +113,13 @@ const AddLiquidity: React.FC = () => {
   }, [lpPair])
 
   const calculateToken1PerToken0 = useCallback(() => {
-    if (typeof lpPair === 'undefined') return '0'
+    if (typeof lpPair === 'undefined' || lpPair === null) return '0'
     const ratio = lpPair.token1Price.raw.toSignificant(2)
     return ratio
   }, [lpPair])
 
   const caculatePoolShare = useCallback(() => {
-    if (typeof lpPair === 'undefined') return '0'
+    if (typeof lpPair === 'undefined' || lpPair === null) return '0'
     const poolShare = BigNumber.from(parseEther(lpTotalSupply)).gt(0)
       ? BigNumber.from(parseEther(lp))
           .mul(parseEther('1'))
@@ -129,7 +129,7 @@ const AddLiquidity: React.FC = () => {
   }, [lpPair, lp, lpTotalSupply])
 
   const calculateOutput = useCallback(() => {
-    if (typeof lpPair === 'undefined') return '0'
+    if (typeof lpPair === 'undefined' || lpPair === null) return '0'
     const reservesA = lpPair.reserveOf(
       new Token(chainId, item.entity.assetAddresses[2], 18)
     )
@@ -153,6 +153,7 @@ const AddLiquidity: React.FC = () => {
   const calculateLiquidityValuePerShare = useCallback(() => {
     if (
       typeof lpPair === 'undefined' ||
+      lpPair === null ||
       BigNumber.from(parseEther(lpTotalSupply)).isZero()
     )
       return {

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -135,7 +135,8 @@ const Swap: React.FC = () => {
     if (item.premium) {
       const premium = BigNumber.from(item.premium.toString())
       const size = inputs.primary === '' ? '0' : inputs.primary
-      debit = formatEther(premium.mul(size).toString())
+      const sizeWei = parseEther(size)
+      debit = formatEther(premium.mul(sizeWei).div(parseEther('1')).toString())
     }
     return debit
   }, [item, inputs])
@@ -208,7 +209,7 @@ const Swap: React.FC = () => {
       ) : (
         <> </>
       )}
-      {parseEther(tokenAllowance).gt(inputs.primary.toString() || '0') ? (
+      {parseEther(tokenAllowance).gt(parseEther(inputs.primary || '0')) ? (
         <Button
           disabled={!inputs || loading}
           full


### PR DESCRIPTION
… BigNumbers.

Changelog
- In Swap component, the calculateTotalDebit() function will multiply the premium by the order size. If order size is a decimal, it will cause an error. The solution is to convert the input to a BigNumber wei value using ethers.lib.parseEther(). Since we are multiplying by two wei values, we have to divide by 10^18. This prevents decimals from causing errors.
- In AddLiquidity component, the `lpPair` is checked against being `undefined` but there are cases where it is null. Added a case that will handle `lpPair` when its null.