### PR TITLE
Fixes the reserve data not showing in the table.

### DIFF
--- a/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
@@ -22,7 +22,7 @@ const OptionsTableHeader: React.FC = () => {
         'The current spot price of an option token, not accounting for slippage.',
     },
     { name: '2% Depth', tip: '# of options can be bought at <2% slippage' },
-    { name: 'Reserve', tip: 'The quantity of tokens in the pool.' },
+    { name: 'Liquidity', tip: 'The quantity of tokens in the pool.' },
     { name: 'Contract', tip: 'The address of the Option token.' },
     { name: '', tip: null },
   ]

--- a/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
@@ -15,6 +15,8 @@ import { useItem } from '@/state/order/hooks'
 
 import GreeksTableRow, { Greeks } from '../GreeksTableRow'
 
+import numeral from 'numeral'
+
 export interface TableColumns {
   key: string
   asset: string
@@ -78,23 +80,25 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
       >
         <TableCell>${strike}</TableCell>
         <TableCell>$ {breakeven}</TableCell>
-        {+premium > 0 ? (
+        {premium !== '0.00' ? (
           <TableCell>
             $ {premium} / {premiumUnderlying} {asset}
           </TableCell>
         ) : (
           <TableCell>-</TableCell>
         )}
-        {+depth > 0 ? (
+        {depth !== '0.00' ? (
           <TableCell>
             {depth} {'Options'}
           </TableCell>
         ) : (
           <TableCell>-</TableCell>
         )}
-        {+reserves[0] > 0 ? (
+        {reserves[0] !== '0.00' ? (
           <TableCell>
-            {reserves[0]} {asset.toUpperCase()} / {reserves[1]} {'SHORT'}
+            {numeral(reserves[0]).format('0a')}{' '}
+            <Units>{asset.toUpperCase()}</Units> /{' '}
+            {numeral(reserves[1]).format('0a')} <Units>{'SHORT'}</Units>
           </TableCell>
         ) : (
           <TableCell>-</TableCell>
@@ -144,6 +148,11 @@ const StyledButtonCell = styled.div`
   flex: 0.25;
   justify-content: center;
   margin-right: ${(props) => props.theme.spacing[2]}px;
+`
+
+const Units = styled.span`
+  opacity: 0.66;
+  font-size: 12px;
 `
 
 export default OptionsTableRow

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -177,7 +177,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                           [reserves0, reserves1]
                         )
                         let reserve: BigNumberish = reserves1.toString()
-                        let depth: BigNumberish = +reserves1 * 0.02
+                        let depth: BigNumberish = redeemCostDivMinted
                         if (typeof reserve === 'undefined') {
                           reserve = 0
                           depth = 0
@@ -186,6 +186,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                         pairReserveTotal = pairReserveTotal.add(
                           BigNumber.from(reserves1)
                         )
+
                         if (option.isCall) {
                           if (
                             Base.asset.symbol.toUpperCase() ===
@@ -198,6 +199,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               premium,
                               true
                             )
+
                             calls.push({
                               entity: option,
                               asset: assetName,
@@ -209,7 +211,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               reserves: reserves,
                               token0: token0,
                               token1: token1,
-                              depth: redeemCostDivMinted.toString(),
+                              depth: depth.toString(),
                               address: option.address,
                               expiry: option.expiry,
                               id: option.name,
@@ -238,9 +240,6 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               option.quote.asset,
                               numerator.div(denominator)
                             )
-                            console.log(
-                              option.optionParameters.base.quantity.toString()
-                            )
                             breakEven = calculateBreakeven(
                               parseEther(strikePrice.quantity.toString()),
                               premium,
@@ -258,7 +257,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               reserves: reserves,
                               token0: token0,
                               token1: token1,
-                              depth: redeemCostDivMinted.toString(),
+                              depth: depth.toString(),
                               address: option.address,
                               expiry: option.expiry,
                               id: option.name,

--- a/app/src/utils/formatEtherBalance.ts
+++ b/app/src/utils/formatEtherBalance.ts
@@ -1,5 +1,6 @@
 import { BigNumberish } from 'ethers'
 import { formatEther } from 'ethers/lib/utils'
+import numeral from 'numeral'
 const formatEtherBalance = (
   tokenBalance: string | number | BigNumberish
 ): BigNumberish => {


### PR DESCRIPTION
- In the `OptionsTableRow` component, there is a check `+reserves[0] > 0`. This seems to not return true in most cases, even when reserves is greater than 0. This could be due to the formatting of the reserves number (which is formatted before being passed as a prop to the table row component).  I changed the conditional statement to `reserves[0] !== '0.00'`, which is a partial fix. This is because if the reserves are 0, it will still get formatted to the string `0.00`. 

- Also changed the table column header from `Reserve` to `Liquidity`. 
- Added numeral npm package to format liquidity values from `000,000` to `000k`.

To do:
- There needs to be a lot of work done with consistent values and value formatting. Right now its a mix between numeral/BigNumber/BigNumberish/strings/numbers/wei... Working on this in next pr.