### PR TITLE
Feedback Changes from #146

### DIFF
--- a/app/src/components/LitContainer/LitContainer.tsx
+++ b/app/src/components/LitContainer/LitContainer.tsx
@@ -12,7 +12,7 @@ const LitContainer: React.FC = (props) => {
 const StyledLitContainer = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: flex-start;
 `
 const StyledLitContainerContent = styled.div`
   width: ${(props) => props.theme.contentWidth * (2 / 3)}px;

--- a/app/src/components/Market/FilterBar/FilterBar.tsx
+++ b/app/src/components/Market/FilterBar/FilterBar.tsx
@@ -65,7 +65,6 @@ const SelectTitle = styled.div`
   margin: 1em;
 `
 const StyledFilterBar = styled.div`
-  background: ${(props) => props.theme.color.black};
   border-radius: 2em;
   margin-left: -0.5em;
   padding: 1em 0 1em 0;

--- a/app/src/components/Market/FilterBar/FilterBar.tsx
+++ b/app/src/components/Market/FilterBar/FilterBar.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import LitContainer from '@/components/LitContainer'
 import Toggle from '@/components/Toggle'
+import Label from '@/components/Label'
 import ToggleButton from '@/components/ToggleButton'
 import Spacer from '@/components/Spacer'
 
@@ -41,6 +42,10 @@ const FilterBar: React.FC<FilterBarProps> = (props) => {
           </Toggle>
           <Spacer size="lg" />
           <StyledSelectWrapper>
+            <SelectTitle>
+              <StyledSymbol>Expiry</StyledSymbol>
+              <Spacer size="sm" />
+            </SelectTitle>
             <StyledSelect value={expiry} onChange={handleFilter}>
               <StyledOption>December 30th, 2020</StyledOption>
             </StyledSelect>
@@ -51,12 +56,25 @@ const FilterBar: React.FC<FilterBarProps> = (props) => {
   )
 }
 
+const SelectTitle = styled.div`
+  color: ${(props) => props.theme.color.grey[400]};
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  margin: 1em;
+`
 const StyledFilterBar = styled.div`
   background: ${(props) => props.theme.color.black};
   border-radius: 2em;
-  padding: 1em;
+  margin-left: -0.5em;
+  padding: 1em 0 1em 0;
 `
-
+const StyledSymbol = styled.span`
+  color: ${(props) => props.theme.color.grey[400]};
+  letter-spacing: 1px;
+  text-transform: uppercase;
+`
 const StyledFilterBarInner = styled.div`
   align-items: center;
   display: flex;
@@ -66,7 +84,11 @@ const StyledFilterBarInner = styled.div`
 const StyledSelectWrapper = styled.div`
   padding: 1em;
   border-radius: 1em;
-  width: 40%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 45%;
 `
 
 const StyledSelect = styled.select`
@@ -75,6 +97,7 @@ const StyledSelect = styled.select`
   color: ${(props) => props.theme.color.grey[400]};
   margin-right: ${(props) => props.theme.spacing[7]}px;
   padding: ${(props) => props.theme.spacing[3]}px;
+  border-radius: 0.5em;
   width: 100%;
 `
 const StyledOption = styled.option``

--- a/app/src/components/Market/FilterBar/FilterBar.tsx
+++ b/app/src/components/Market/FilterBar/FilterBar.tsx
@@ -92,7 +92,7 @@ const StyledSelectWrapper = styled.div`
 
 const StyledSelect = styled.select`
   align-items: center;
-  background: ${(props) => props.theme.color.grey[800]};
+  background: ${(props) => props.theme.color.black};
   color: ${(props) => props.theme.color.grey[400]};
   margin-right: ${(props) => props.theme.spacing[7]}px;
   padding: ${(props) => props.theme.spacing[3]}px;

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -79,6 +79,8 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
 
   return (
     <StyledHeader>
+      <GreyBack />
+      <Spacer />
       <GoBack to="/markets" />
 
       <LitContainer>
@@ -153,6 +155,14 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
   )
 }
 
+const GreyBack = styled.div`
+  background: ${(props) => props.theme.color.grey[800]};
+  position: absolute;
+  z-index: -100;
+  min-height: 342px;
+  min-width: 1200px;
+  left: 0;
+`
 const StyledContent = styled(Box)`
   align-items: baseline;
   flex-direction: row;
@@ -165,7 +175,6 @@ const StyledIcon = styled(LaunchIcon)`
 `
 const StyledHeader = styled.div`
   padding-bottom: ${(props) => props.theme.spacing[4]}px;
-  padding-top: ${(props) => props.theme.spacing[4]}px;
 `
 const StyledLink = styled.a`
   text-decoration: none;

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -163,7 +163,6 @@ const StyledIcon = styled(LaunchIcon)`
   margin-left: 10px;
 `
 const StyledHeader = styled.div`
-  background-color: ${(props) => props.theme.color.black};
   padding-bottom: ${(props) => props.theme.spacing[4]}px;
   padding-top: ${(props) => props.theme.spacing[4]}px;
 `

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -90,7 +90,6 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
           <Spacer size="lg" />
           <StyledContent>
             <StyledSymbol>{symbol.toUpperCase()}</StyledSymbol>
-            <Spacer size="sm" />
             <StyledLink
               href={`${baseUrl}/${address}`}
               target="_blank"
@@ -114,7 +113,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
             </StyledPrice>
           </StyledContent>
 
-          <Spacer />
+          <Spacer size="lg" />
           <StyledContent>
             <StyledSymbol>24hr Change</StyledSymbol>
             <Spacer size="sm" />
@@ -127,7 +126,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
             </StyledPrice>
           </StyledContent>
 
-          <Spacer />
+          <Spacer size="lg" />
           <StyledContent>
             <StyledSymbol>Total Liquidity</StyledSymbol>
             <Spacer size="sm" />
@@ -159,7 +158,7 @@ const GreyBack = styled.div`
   background: ${(props) => props.theme.color.grey[800]};
   position: absolute;
   z-index: -100;
-  min-height: 342px;
+  min-height: 338px;
   min-width: 1200px;
   left: 0;
 `

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -112,7 +112,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
             </StyledPrice>
           </StyledContent>
 
-          <Spacer size="lg" />
+          <Spacer />
           <StyledContent>
             <StyledSymbol>24hr Change</StyledSymbol>
             <Spacer size="sm" />
@@ -125,7 +125,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
             </StyledPrice>
           </StyledContent>
 
-          <Spacer size="lg" />
+          <Spacer />
           <StyledContent>
             <StyledSymbol>Total Liquidity</StyledSymbol>
             <Spacer size="sm" />
@@ -146,6 +146,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
               )}
             </StyledPrice>
           </StyledContent>
+          <Spacer size="lg" />
         </StyledTitle>
       </LitContainer>
     </StyledHeader>

--- a/app/src/components/Market/OptionsTable/NewMarketRow/NewMarketRow.tsx
+++ b/app/src/components/Market/OptionsTable/NewMarketRow/NewMarketRow.tsx
@@ -29,6 +29,7 @@ const StyledButtonCellError = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  cursor: pointer;
   font-weight: inherit;
   color: ${(props) => props.theme.color.white};
   margin-right: ${(props) => props.theme.spacing[2]}px;

--- a/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
@@ -54,7 +54,6 @@ const OptionsTableHeader: React.FC = () => {
   )
 }
 const StyledTableHead = styled.div`
-  background-color: ${(props) => props.theme.color.grey[800]};
   border-bottom: 1px solid ${(props) => props.theme.color.grey[600]};
 `
 

--- a/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
@@ -54,7 +54,7 @@ const OptionsTableHeader: React.FC = () => {
   )
 }
 const StyledTableHead = styled.div`
-  border-bottom: 1px solid ${(props) => props.theme.color.grey[600]};
+  border-bottom: 0px solid ${(props) => props.theme.color.grey[600]};
 `
 
 const StyledButtonCell = styled.div`

--- a/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
@@ -54,7 +54,7 @@ const OptionsTableHeader: React.FC = () => {
   )
 }
 const StyledTableHead = styled.div`
-  background-color: ${(props) => props.theme.color.black};
+  background-color: ${(props) => props.theme.color.grey[800]};
   border-bottom: 1px solid ${(props) => props.theme.color.grey[600]};
 `
 

--- a/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
@@ -114,9 +114,10 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
                 ? 'selected-outlined'
                 : 'outlined'
             }
+            size="sm"
           >
             {item.entity === null ? (
-              <AddIcon />
+              <AddIcon style={{ fontSize: '2em' }} />
             ) : item?.entity.address === key ? (
               <CheckIcon />
             ) : (

--- a/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
@@ -64,7 +64,7 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
     setToggle(false)
   })
   return (
-    <div ref={nodeRef}>
+    <StyledDiv ref={nodeRef}>
       <TableRow
         isActive={
           item.entity === null
@@ -131,13 +131,17 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
       ) : (
         <></>
       )}
-    </div>
+    </StyledDiv>
   )
 }
 
 const StyledARef = styled.a`
   color: ${(props) => props.theme.color.white};
   text-decoration: none;
+`
+
+const StyledDiv = styled.div`
+  color: black;
 `
 
 const StyledButtonCell = styled.div`

--- a/app/src/components/Market/OrderCard/OrderCard.tsx
+++ b/app/src/components/Market/OrderCard/OrderCard.tsx
@@ -6,6 +6,8 @@ import { useOptions } from '@/state/options/hooks'
 import ClearIcon from '@material-ui/icons/Clear'
 
 import Button from '@/components/Button'
+import Spacer from '@/components/Spacer'
+
 import Box from '@/components/Box'
 import Card from '@/components/Card'
 import CardContent from '@/components/CardContent'
@@ -14,7 +16,11 @@ import Submit from './components/Submit'
 import OrderOptions from './components/OrderOptions'
 import formatBalance from '@/utils/formatBalance'
 import formatExpiry from '@/utils/formatExpiry'
-import { Operation } from '@/constants/index'
+import {
+  Operation,
+  getIconForMarket,
+  COINGECKO_ID_FOR_MARKET,
+} from '@/constants/index'
 import { EmptyAttributes } from '@/state/options/reducer'
 
 const OrderContent: React.FC = () => {
@@ -70,19 +76,24 @@ const OrderCard: React.FC<OrderProps> = ({ orderState }) => {
   }
   return (
     <Card>
-      <CardTitle>
-        <StyledTitle>
-          <>
-            {`${item.asset} ${
-              item.entity.isCall ? 'Call' : 'Put'
-            } $${formatBalance(item.strike)} ${month}/${date} ${year}`}
-          </>
-          <StyledFlex />
+      <Box row justifyContent="space-between" alignItems="center">
+        <StyledLogo src={getIconForMarket(item.asset.toLowerCase())} alt={''} />
+        <div>
+          <StyledTitle>
+            {`${item.asset} ${item.entity.isCall ? 'Call' : 'Put'}`}
+          </StyledTitle>
+          <Reverse />
+          <StyledTitle>
+            {`$${formatBalance(item.strike)} ${month}/${date} ${year}`}
+          </StyledTitle>
+        </div>
+        <Spacer />
+        <CustomButton>
           <Button variant="transparent" size="sm" onClick={() => clear()}>
             <ClearIcon />
           </Button>
-        </StyledTitle>
-      </CardTitle>
+        </CustomButton>
+      </Box>
       <CardContent>
         <OrderContent />
       </CardContent>
@@ -90,18 +101,25 @@ const OrderCard: React.FC<OrderProps> = ({ orderState }) => {
   )
 }
 
-const StyledTitle = styled(Box)`
-  align-items: center;
-  border-bottom: 0px solid ${(props) => props.theme.color.grey[600]};
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  width: 100%;
+const CustomButton = styled.div`
+  margin-top: -1.1em;
+  background: none;
+`
+const Reverse = styled.div`
+  margin-top: -1.1em;
 `
 
-const StyledFlex = styled.div`
-  display: flex;
-  flex: 1;
+const StyledTitle = styled.h4`
+  align-items: center;
+  border-bottom: 0px solid ${(props) => props.theme.color.grey[600]};
+  width: 100%;
+  color: white;
+`
+
+const StyledLogo = styled.img`
+  border-radius: 50%;
+  margin-left: 1.3em;
+  height: 36px;
 `
 
 export default OrderCard

--- a/app/src/components/Market/OrderCard/OrderCard.tsx
+++ b/app/src/components/Market/OrderCard/OrderCard.tsx
@@ -75,7 +75,7 @@ const OrderCard: React.FC<OrderProps> = ({ orderState }) => {
     removeItem()
   }
   return (
-    <Card>
+    <Card border>
       <Box row justifyContent="space-between" alignItems="center">
         <StyledLogo src={getIconForMarket(item.asset.toLowerCase())} alt={''} />
         <div>

--- a/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
+++ b/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
@@ -48,14 +48,14 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
         units={'UNI-V2'}
       />
       <Spacer />
-      <Box row justifyContent="space-around" alignItems="center">
+      <Box row justifyContent="center" alignItems="center">
         <Button size="sm" onClick={() => change(Operation.ADD_LIQUIDITY)}>
-          Provide Liquidity
+          Provide
         </Button>
-        <Spacer size="sm" />
+        <Spacer />
         {balance ? (
           <Button size="sm" variant="secondary" disabled>
-            Withdraw Liquidity
+            Withdraw
           </Button>
         ) : (
           <Button
@@ -63,7 +63,7 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
             variant="secondary"
             onClick={() => change(Operation.REMOVE_LIQUIDITY)}
           >
-            Withdraw Liquidity
+            Withdraw
           </Button>
         )}
       </Box>
@@ -94,91 +94,97 @@ const OrderOptions: React.FC = () => {
   }
 
   return (
-    <Box row alignItems="flex-start" justifyContent="center">
-      <StyledTabs selectedIndex={tab} onSelect={(index) => setTab(index)}>
-        <StyledTabList>
-          <StyledTab active={tab === 0}>Long</StyledTab>
+    <>
+      <Reverse />
+      <Box row alignItems="flex-start" justifyContent="center">
+        <StyledTabs selectedIndex={tab} onSelect={(index) => setTab(index)}>
+          <StyledTabList>
+            <StyledTab active={tab === 0}>Long</StyledTab>
+            <Spacer size="sm" />
+            <StyledTab active={tab === 1}>Short</StyledTab>
+            <Spacer size="sm" />
+            <StyledTab active={tab === 2}>Liquidity</StyledTab>
+          </StyledTabList>
           <Spacer />
-          <StyledTab active={tab === 1}>Short</StyledTab>
-          <Spacer />
-          <StyledTab active={tab === 2}>Pool</StyledTab>
-        </StyledTabList>
-        <Spacer />
-        <TabPanel>
-          <StyledColumn>
-            <Box row justifyContent="flex-start" alignItems="center">
-              <Label text={'Balance'} />
-              <Spacer />
-              <StyledBalance>
-                {positions.loading ? (
-                  <Loader size="sm" />
-                ) : !option.long ? (
-                  '0.00'
-                ) : (
-                  formatEtherBalance(option.long)
-                )}
-              </StyledBalance>
-            </Box>
-            <Box row justifyContent="space-between" alignItems="center">
-              <Button full size="sm" onClick={() => change(Operation.LONG)}>
-                Buy
-              </Button>
-              <Spacer />
-              <Button
-                full
-                disabled={!positions.loading ? false : true}
-                size="sm"
-                variant="secondary"
-                onClick={() => change(Operation.CLOSE_LONG)}
-              >
-                Sell
-              </Button>
-            </Box>
-          </StyledColumn>
-        </TabPanel>
-        <TabPanel>
-          <StyledColumn>
-            <Box row justifyContent="flex-start" alignItems="center">
-              <Label text={'Balance'} />
-              <Spacer />
-              <StyledBalance>
-                {positions.loading ? (
-                  <Loader size="sm" />
-                ) : !option.short ? (
-                  '0.00'
-                ) : (
-                  formatEtherBalance(option.short)
-                )}
-              </StyledBalance>
-            </Box>
-            <Box row justifyContent="space-between" alignItems="center">
-              <Button full size="sm" onClick={() => change(Operation.SHORT)}>
-                Buy
-              </Button>
-              <Spacer />
-              <Button
-                full
-                disabled={!positions.loading ? false : true}
-                size="sm"
-                variant="secondary"
-                onClick={() => change(Operation.CLOSE_SHORT)}
-              >
-                Sell
-              </Button>
-            </Box>
-          </StyledColumn>
-        </TabPanel>
-        <TabPanel>
-          <StyledColumn>
-            <LPOptions balance={option.lp ? option.lp : null} />
-          </StyledColumn>
-        </TabPanel>
-      </StyledTabs>
-    </Box>
+          <TabPanel>
+            <StyledColumn>
+              <Box row justifyContent="flex-start" alignItems="center">
+                <Label text={'Balance'} />
+                <Spacer />
+                <StyledBalance>
+                  {positions.loading ? (
+                    <Loader size="sm" />
+                  ) : !option.long ? (
+                    '0.00'
+                  ) : (
+                    formatEtherBalance(option.long)
+                  )}
+                </StyledBalance>
+              </Box>
+              <Box row justifyContent="space-between" alignItems="center">
+                <Button full size="sm" onClick={() => change(Operation.LONG)}>
+                  Buy
+                </Button>
+                <Spacer />
+                <Button
+                  full
+                  disabled={!positions.loading ? false : true}
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => change(Operation.CLOSE_LONG)}
+                >
+                  Sell
+                </Button>
+              </Box>
+            </StyledColumn>
+          </TabPanel>
+          <TabPanel>
+            <StyledColumn>
+              <Box row justifyContent="flex-start" alignItems="center">
+                <Label text={'Balance'} />
+                <Spacer />
+                <StyledBalance>
+                  {positions.loading ? (
+                    <Loader size="sm" />
+                  ) : !option.short ? (
+                    '0.00'
+                  ) : (
+                    formatEtherBalance(option.short)
+                  )}
+                </StyledBalance>
+              </Box>
+              <Box row justifyContent="space-between" alignItems="center">
+                <Button full size="sm" onClick={() => change(Operation.SHORT)}>
+                  Buy
+                </Button>
+                <Spacer />
+                <Button
+                  full
+                  disabled={!positions.loading ? false : true}
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => change(Operation.CLOSE_SHORT)}
+                >
+                  Sell
+                </Button>
+              </Box>
+            </StyledColumn>
+          </TabPanel>
+          <TabPanel>
+            <StyledColumn>
+              <LPOptions balance={option.lp ? option.lp : null} />
+            </StyledColumn>
+          </TabPanel>
+        </StyledTabs>
+      </Box>
+    </>
   )
 }
 const StyledTabs = styled(Tabs)`
   width: 100%;
+`
+const Reverse = styled.div`
+  margin-top: -1.1em;
 `
 
 const StyledTabList = styled(TabList)`
@@ -203,8 +209,9 @@ const StyledTab = styled(Tab)<TabProps>`
   border-width: 1px 1px 0 1px;
   border-style: solid;
   border-color: ${(props) => props.theme.color.grey[600]};
-  width: 20%;
+  width: 22%;
   list-style: none;
+  cursor: pointer;
 `
 
 const StyledColumn = styled.div`

--- a/app/src/components/Market/PositionsCard/PositionsCard.tsx
+++ b/app/src/components/Market/PositionsCard/PositionsCard.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState, useContext } from 'react'
 import styled from 'styled-components'
 
 import AddIcon from '@material-ui/icons/Add'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import ExpandLessIcon from '@material-ui/icons/ExpandLess'
 
 import LaunchIcon from '@material-ui/icons/Launch'
 
@@ -13,6 +15,7 @@ import Card from '@/components/Card'
 import CardContent from '@/components/CardContent'
 import CardTitle from '@/components/CardTitle'
 import Spacer from '@/components/Spacer'
+import IconButton from '@/components/IconButton'
 import Box from '@/components/Box'
 import Button from '@/components/Button'
 import Loader from '@/components/Loader'
@@ -79,17 +82,14 @@ const Position: React.FC<TokenProps> = ({ option }) => {
       <StyledPrices row justifyContent="space-between" alignItems="center">
         <StyledPrice>
           <StyledT>Long</StyledT>
-          <Spacer size="sm" />
           {formatEtherBalance(option.long)}
         </StyledPrice>
         <StyledPrice>
           <StyledT>Short</StyledT>
-          <Spacer size="sm" />
           {formatEtherBalance(option.redeem)}
         </StyledPrice>
         <StyledPrice>
           <StyledT>LP</StyledT>
-          <Spacer size="sm" />
           {formatEtherBalance(option.lp)}
         </StyledPrice>
       </StyledPrices>
@@ -100,6 +100,7 @@ const Position: React.FC<TokenProps> = ({ option }) => {
 const PositionsCard: React.FC = () => {
   const item = useItem()
   const positions = usePositions()
+  const [open, setOpen] = useState(false)
 
   if (item.item.asset) return null
   if (positions.loading) {
@@ -123,28 +124,54 @@ const PositionsCard: React.FC = () => {
     )
   }
   return (
-    <Card>
-      <CardTitle>Active Positions</CardTitle>
-      <CardContent>
-        {positions.options.map((pos, i) => {
-          return <Position key={i} option={pos} />
-        })}
-      </CardContent>
+    <Card border>
+      <Reverse />
+      <CardTitle>
+        <div onClick={() => setOpen(!open)}>
+          <StyledBox row justifyContent="space-around" alignItems="center">
+            <Title>{`Active Positions (${positions.options.length})`}</Title>
+            <IconButton variant="tertiary">
+              {open ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+            </IconButton>
+          </StyledBox>
+        </div>
+      </CardTitle>
+      <Reverse />
+      {open ? null : (
+        <>
+          <CardContent>
+            {positions.options.map((pos, i) => {
+              return <Position key={i} option={pos} />
+            })}
+          </CardContent>
+          <Spacer size="sm" />
+        </>
+      )}
     </Card>
   )
 }
 
+const StyledBox = styled(Box)`
+  cursor: pointer;
+`
+
+const Title = styled.h4`
+  color: white;
+  min-width: 16em;
+`
 const Reverse = styled.div`
   margin-top: -1.1em;
 `
 const StyledT = styled.h5`
   opacity: 66%;
+  margin-bottom: -2px;
+  margin-top: -0px;
 `
 
 const StyledPrice = styled.div`
   display: flex;
-  flex-direction: row;
-  align-items: baseline;
+  flex-direction: column;
+  padding: 0.3em;
   color: white;
 `
 const StyledPrices = styled(Box)`
@@ -164,7 +191,7 @@ const StyledTitle = styled.h3`
   margin-top: -0.5em;
 `
 const StyledPosition = styled.a`
-  border: 2px solid ${(props) => props.theme.color.grey[600]};
+  border: 1px solid ${(props) => props.theme.color.grey[800]};
   border-radius: ${(props) => props.theme.borderRadius}px;
   background: ${(props) => props.theme.color.black};
   min-height: 2em;

--- a/app/src/components/Market/PositionsCard/PositionsCard.tsx
+++ b/app/src/components/Market/PositionsCard/PositionsCard.tsx
@@ -29,6 +29,7 @@ import { usePositions } from '@/state/positions/hooks'
 import { useUpdateItem, useItem } from '@/state/order/hooks'
 import formatEtherBalance from '@/utils/formatEtherBalance'
 import formatExpiry from '@/utils/formatExpiry'
+import LineItem from '@/components/LineItem'
 export interface TokenProps {
   option: any // replace with option type
 }
@@ -47,6 +48,7 @@ const Position: React.FC<TokenProps> = ({ option }) => {
   return (
     <StyledPosition onClick={handleClick}>
       <Box row justifyContent="space-around" alignItems="center">
+        <Spacer size="sm" />
         <StyledLogo
           src={getIconForMarket(option.attributes.asset.toLowerCase())}
           alt={''}
@@ -59,6 +61,7 @@ const Position: React.FC<TokenProps> = ({ option }) => {
               option.attributes.entity.isCall ? 'Call' : 'Put'
             }`}
           </StyledTitle>
+          <Reverse />
           <StyledTitle>
             {`$${option.attributes.strike} ${month}/${date} ${year}`}
           </StyledTitle>
@@ -74,9 +77,21 @@ const Position: React.FC<TokenProps> = ({ option }) => {
       </Box>
       <Spacer size="sm" />
       <StyledPrices row justifyContent="space-between" alignItems="center">
-        <span>Long {formatEtherBalance(option.long)}</span>
-        <span>Short {formatEtherBalance(option.redeem)}</span>
-        <span>LP {formatEtherBalance(option.lp)}</span>
+        <StyledPrice>
+          <StyledT>Long</StyledT>
+          <Spacer size="sm" />
+          {formatEtherBalance(option.long)}
+        </StyledPrice>
+        <StyledPrice>
+          <StyledT>Short</StyledT>
+          <Spacer size="sm" />
+          {formatEtherBalance(option.redeem)}
+        </StyledPrice>
+        <StyledPrice>
+          <StyledT>LP</StyledT>
+          <Spacer size="sm" />
+          {formatEtherBalance(option.lp)}
+        </StyledPrice>
       </StyledPrices>
     </StyledPosition>
   )
@@ -119,6 +134,19 @@ const PositionsCard: React.FC = () => {
   )
 }
 
+const Reverse = styled.div`
+  margin-top: -1.1em;
+`
+const StyledT = styled.h5`
+  opacity: 66%;
+`
+
+const StyledPrice = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  color: white;
+`
 const StyledPrices = styled(Box)`
   border-radius: 5px;
   border-width: 1px;
@@ -126,7 +154,7 @@ const StyledPrices = styled(Box)`
   background: ${(props) => props.theme.color.black};
   border-style: solid;
   margin: 0 0.5em 0 0.5em;
-  padding: 1em;
+  padding: 0 1em 0 1em;
 `
 const StyledTitle = styled.h3`
   color: ${(props) => props.theme.color.white};
@@ -144,7 +172,7 @@ const StyledPosition = styled.a`
   padding-left: 0.8em;
   padding-right: 0.8em;
   padding-bottom: 1em;
-  padding-top: 1em;
+  padding-top: 0.5em;
   cursor: pointer;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
@@ -185,7 +213,7 @@ const StyledEmptyMessage = styled.div`
 
 const StyledLogo = styled.img`
   border-radius: 50%;
-  height: 54px;
+  height: 36px;
 `
 
 export default PositionsCard

--- a/app/src/components/Market/TransactionCard/TransactionCard.tsx
+++ b/app/src/components/Market/TransactionCard/TransactionCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 
 import Box from '@/components/Box'
-import Button from '@/components/Button'
+import IconButton from '@/components/Button'
 import Card from '@/components/Card'
 import CardContent from '@/components/CardContent'
 import CardTitle from '@/components/CardTitle'
@@ -39,19 +39,21 @@ const TransactionCard: React.FC = () => {
   if (Object.keys(txs).length === 0 && txs.constructor === Object) return null
   return (
     <>
-      <Card>
+      <Card border>
         <CardTitle>
-          <StyledTitle>Recent Transactions</StyledTitle>
-          <Button variant="transparent" size="sm" onClick={() => clear()}>
-            <ClearIcon />
-          </Button>
+          <Box row justifyContent="space-around" alignItems="center">
+            <StyledTitle>Recent Transactions</StyledTitle>
+            <IconButton variant="transparent" size="sm" onClick={() => clear()}>
+              <ClearIcon />
+            </IconButton>
+          </Box>
         </CardTitle>
         <CardContent>
           <StyledContainer>
             <Table>
               <TableRow>
                 <TableCell>Time</TableCell>
-                <TableCell>Operation</TableCell>
+                <TableCell>Type</TableCell>
                 <TableCell>Hash</TableCell>
                 <TableCell>Status</TableCell>
               </TableRow>
@@ -114,6 +116,10 @@ const TransactionCard: React.FC = () => {
   )
 }
 
+const Reverse = styled.div`
+  margin-top: -1.1em;
+`
+
 const StyledContainer = styled.div`
   width: 110%;
   justify-content: space-around;
@@ -142,6 +148,7 @@ const StyledTitle = styled(Box)`
   align-items: center;
   display: flex;
   flex-direction: row;
+  min-width: 15.7em;
   width: 100%;
 `
 

--- a/app/src/components/TableRow/TableRow.tsx
+++ b/app/src/components/TableRow/TableRow.tsx
@@ -38,7 +38,8 @@ const StyledTableRow = styled.div<StyleProps>`
   padding-left: ${(props) => props.theme.spacing[4]}px;
   padding-right: ${(props) => props.theme.spacing[4]}px;
   &:hover {
-    background-color: ${(props) => props.theme.color.grey[800]};
+    background-color: ${(props) =>
+      props.isHead ? 'transparent' : props.theme.color.grey[800]};
     color: ${(props) =>
       props.isHead ? props.theme.color.grey[400] : props.theme.color.white};
     font-weight: ${(props) => (props.isHead ? '400' : '600')};

--- a/app/src/components/Toggle/Toggle.tsx
+++ b/app/src/components/Toggle/Toggle.tsx
@@ -20,7 +20,7 @@ const Toggle: React.FC = ({ children }) => {
 
 const StyledSwtich = styled.div`
   align-items: center;
-  background: ${(props) => props.theme.color.grey[800]};
+  background: ${(props) => props.theme.color.black};
   border-radius: ${(props) => props.theme.borderRadius}px;
   display: flex;
   padding: ${(props) => props.theme.spacing[2]}px;

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -96,7 +96,13 @@ const Market = ({ market, data }) => {
   )
 }
 
-const StyledMain = styled.div``
+const StyledMain = styled.div`
+  background: ${(props) => props.theme.color.grey[800]};
+  padding: 0 10em 0 3em;
+  height: 40%;
+  width: 100%;
+  border-radius: 0 0 0 5px;
+`
 
 const StyledMarket = styled.div`
   width: 100%;

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -53,7 +53,7 @@ const Market = ({ market, data }) => {
       <StyledMarket>
         <Grid>
           <Row>
-            <Col sm={12} md={8} lg={8}>
+            <StyledContainer sm={12} md={8} lg={8}>
               <StyledMain>
                 <MarketHeader marketId={market} />
                 <FilterBar
@@ -69,7 +69,8 @@ const Market = ({ market, data }) => {
                   callActive={callPutActive}
                 />
               </StyledMain>
-            </Col>
+            </StyledContainer>
+
             <Col sm={12} md={4} lg={4}>
               <StyledSideBar>
                 <BetaBanner isOpen={true} />
@@ -96,14 +97,14 @@ const Market = ({ market, data }) => {
   )
 }
 
-const StyledMain = styled.div`
-  background: ${(props) => props.theme.color.grey[800]};
-  padding: 0 10em 0 3em;
-  height: 21.25em;
-  border: 1px solid ${(props) => props.theme.color.grey[600]};
-  width: 100%;
-  border-radius: 0 0 0 5px;
+const StyledContainer = styled(Col)`
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
 `
+const StyledMain = styled.div``
 
 const StyledMarket = styled.div`
   width: 100%;

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -53,7 +53,7 @@ const Market = ({ market, data }) => {
       <StyledMarket>
         <Grid>
           <Row>
-            <Col sm={7} md={8} lg={8}>
+            <Col sm={12} md={8} lg={8}>
               <StyledMain>
                 <MarketHeader marketId={market} />
                 <FilterBar
@@ -70,7 +70,7 @@ const Market = ({ market, data }) => {
                 />
               </StyledMain>
             </Col>
-            <Col sm={5} md={4} lg={4}>
+            <Col sm={12} md={4} lg={4}>
               <StyledSideBar>
                 <BetaBanner isOpen={true} />
                 <Spacer size="sm" />
@@ -99,7 +99,8 @@ const Market = ({ market, data }) => {
 const StyledMain = styled.div`
   background: ${(props) => props.theme.color.grey[800]};
   padding: 0 10em 0 3em;
-  height: 40%;
+  height: 21.25em;
+  border: 1px solid ${(props) => props.theme.color.grey[600]};
   width: 100%;
   border-radius: 0 0 0 5px;
 `


### PR DESCRIPTION
Closes #146 

Completed all tasks outlined in issue except for...

Grey Header [DONE] -  This was only possible in previous versions due to how the market main and sidebar were positioned using grid.  To make any part of the market header background grey again, I would need to add a border and create a card-style component to make it look passable, the fixed flexbox grid prevents the header from being grey in the same way.  This is purely a compromise between correct usage of flex for screen sizes and what I also deem to be slightly better looks.

Icon Sizes - The IconButton component does not seem to be using my corrected icon sizes, not sure the best way to go about this so I am waiting to see if this is truly necessary.  