### PR TITLE
Topbar full screen width, no liquidity warning, @material-icons style in prod fix

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "@ethersproject/providers": "^5.0.5",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/styles": "^4.10.0",
     "@metamask/onboarding": "^1.0.0",
     "@reduxjs/toolkit": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",

--- a/app/src/components/Container/Container.tsx
+++ b/app/src/components/Container/Container.tsx
@@ -30,7 +30,7 @@ const StyledContainer = styled.div<StyleProps>`
   height: ${(props) => (props.height ? props.height + 'px' : undefined)};
   justify-content: ${(props) => props.justifyContent};
   margin: 0 auto;
-  max-width: 1200px;
+  max-width: 1800px;
   width: 100%;
 `
 

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -88,9 +88,11 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
         <Spacer />
         <StyledTitle>
           <StyledLogo src={getIconForMarket(symbol)} alt={formatName(name)} />
-          <Spacer size="lg" />
+          <Spacer />
           <StyledContent>
+            <div style={{ marginTop: '.3em' }} />
             <StyledSymbol>{symbol.toUpperCase()}</StyledSymbol>
+            <div style={{ marginTop: '.1em' }} />
             <StyledLink
               href={`${baseUrl}/${address}`}
               target="_blank"
@@ -101,7 +103,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
             </StyledLink>
           </StyledContent>
 
-          <Spacer size="lg" />
+          <Spacer size="md" />
           <StyledContent>
             <StyledSymbol>Price</StyledSymbol>
             <Spacer size="sm" />
@@ -143,7 +145,7 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
                     <Spacer size="sm" />
                     <h4>
                       <Tooltip
-                        text={`This Market has no liquidty, click an option and navigate to the Liquidity tab to initalize this market!`}
+                        text={`This option market has no liquidty, click an option and navigate to the Liquidity tab to initalize trading.`}
                       >
                         N/A{' '}
                       </Tooltip>
@@ -215,7 +217,7 @@ const StyledName = styled.span`
   text-decoration: none;
   cursor: pointer;
   &:hover {
-    color: ${(props) => props.theme.color.white};
+    color: ${(props) => props.theme.color.grey[400]};
   }
 `
 

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import Box from '@/components/Box'
 import GoBack from '@/components/GoBack'
 import LitContainer from '@/components/LitContainer'
+import Tooltip from '@/components/Tooltip'
 import Spacer from '@/components/Spacer'
 import Loader from '@/components/Loader'
 import LaunchIcon from '@material-ui/icons/Launch'
@@ -137,10 +138,17 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
                     options.reservesTotal
                   )}  ${symbol.toUpperCase()}`
                 ) : (
-                  <>
+                  <StyledL row justifyContent="flex-start" alignItems="center">
                     <WarningIcon style={{ color: 'yellow' }} />
-                    <h4>This market has no liquidity</h4>
-                  </>
+                    <Spacer size="sm" />
+                    <h4>
+                      <Tooltip
+                        text={`This Market has no liquidty, click an option and navigate to the Liquidity tab to initalize this market!`}
+                      >
+                        N/A{' '}
+                      </Tooltip>
+                    </h4>
+                  </StyledL>
                 )
               ) : (
                 <Loader size="sm" />
@@ -153,6 +161,10 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
     </StyledHeader>
   )
 }
+const StyledL = styled(Box)`
+  margin-top: -1.5em;
+  margin-bottom: -1.1em;
+`
 
 const GreyBack = styled.div`
   background: ${(props) => props.theme.color.grey[800]};

--- a/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
@@ -29,6 +29,7 @@ const OptionsTableHeader: React.FC = () => {
 
   return (
     <StyledTableHead>
+      <GreyBack />
       <LitContainer>
         <TableRow isHead>
           {headers.map((header, index) => {
@@ -53,6 +54,16 @@ const OptionsTableHeader: React.FC = () => {
     </StyledTableHead>
   )
 }
+
+const GreyBack = styled.div`
+  background: ${(props) => props.theme.color.grey[800]};
+  position: absolute;
+  z-index: -100;
+  min-height: 60px;
+  min-width: 1200px;
+  left: 0;
+`
+
 const StyledTableHead = styled.div`
   border-bottom: 0px solid ${(props) => props.theme.color.grey[600]};
 `

--- a/app/src/components/Settings/Settings.tsx
+++ b/app/src/components/Settings/Settings.tsx
@@ -33,6 +33,7 @@ export const Settings = () => {
         <StyledModal ref={nodeRef}>
           <StyledContent>
             <StyledTitle>Settings</StyledTitle>
+            <Spacer size="sm" />
             <StyledSetting>Slippage tolerance</StyledSetting>
             <Spacer size="sm" />
             <StyledRow>
@@ -122,10 +123,10 @@ const StyledModal = styled.div`
   border-radius: ${(props) => props.theme.borderRadius}px;
   color: ${(props) => props.theme.color.white};
   padding: ${(props) => props.theme.spacing[3]}px;
-  margin: 1em;
+  margin: 0.5em;
   position: fixed;
   right: 0%;
-  top: ${(props) => props.theme.barHeight + 1}px;
+  top: ${(props) => props.theme.barHeight}px;
   z-index: 0;
   z-index: 9999 !important;
 `

--- a/app/src/components/Tooltip/Tooltip.tsx
+++ b/app/src/components/Tooltip/Tooltip.tsx
@@ -42,14 +42,15 @@ const StyledContainer = styled.div`
   cursor: pointer;
 `
 const Tip = styled.div`
-  width: 120px;
+  max-width: 20em;
+  min-width: 10em;
   background-color: black;
   color: ${(props) => props.theme.color.white};
   text-align: center;
   padding: 10px;
   border-radius: 6px;
-  top: 1em;
-  left: 5em;
+  top: 0.2em;
+  left: 2em;
   /* Position the tooltip text - see examples below! */
   position: absolute;
   z-index: 1;

--- a/app/src/components/Tooltip/Tooltip.tsx
+++ b/app/src/components/Tooltip/Tooltip.tsx
@@ -49,7 +49,7 @@ const Tip = styled.div`
   text-align: center;
   padding: 10px;
   border-radius: 6px;
-  top: 0.2em;
+  top: 1.5em;
   left: 2em;
   /* Position the tooltip text - see examples below! */
   position: absolute;

--- a/app/src/components/TopBar/TopBar.tsx
+++ b/app/src/components/TopBar/TopBar.tsx
@@ -82,13 +82,13 @@ const StyledTopBar = styled.div`
   height: 72px;
   position: sticky;
   top: 0;
-  width: 100%;
 `
 
 const StyledFlex = styled.div`
   align-items: center;
   display: flex;
-  flex: 1;
+  flex: 0.2;
+  margin: 0 1em 0 1em;
 `
 
 const StyledNav = styled.div`

--- a/app/src/pages/_document.tsx
+++ b/app/src/pages/_document.tsx
@@ -1,33 +1,41 @@
 import React from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { ServerStyleSheets } from '@material-ui/styles'
+// THIS FILE IS REQUIRED FOR MATERIAL-UI STYLES TO LOAD IN NEXT.JS
+//  reference: https://github.com/mui-org/material-ui/blob/master/examples/nextjs/pages/_document.js
+//
 import { ServerStyleSheet } from 'styled-components'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
-    const sheet = new ServerStyleSheet()
+    const styledComponentsSheet = new ServerStyleSheet()
+    const materialSheets = new ServerStyleSheets()
     const originalRenderPage = ctx.renderPage
 
     try {
       ctx.renderPage = () =>
         originalRenderPage({
           enhanceApp: (App) => (props) =>
-            sheet.collectStyles(<App {...props} />),
+            styledComponentsSheet.collectStyles(
+              materialSheets.collect(<App {...props} />)
+            ),
         })
-
       const initialProps = await Document.getInitialProps(ctx)
       return {
         ...initialProps,
         styles: (
-          <>
+          <React.Fragment>
             {initialProps.styles}
-            {sheet.getStyleElement()}
-          </>
+            {materialSheets.getStyleElement()}
+            {styledComponentsSheet.getStyleElement()}
+          </React.Fragment>
         ),
       }
     } finally {
-      sheet.seal()
+      styledComponentsSheet.seal()
     }
   }
+
   render() {
     return (
       <Html>


### PR DESCRIPTION
Closes #103 
Closes #117 

#104 Partially Completed

Changelog
- Added @material-ui/styles to support material-ui styles and styled-components for proper icon loading in prod
- Forced the topbar to the edges with a new max width for actually big screens
- Added no liquidity warning
- Various style updates