### PR TITLE
Metamask event support for network changed, no network fallback for markets page

### DIFF
--- a/app/src/components/Market/FilterBar/FilterBar.tsx
+++ b/app/src/components/Market/FilterBar/FilterBar.tsx
@@ -66,7 +66,7 @@ const SelectTitle = styled.div`
 `
 const StyledFilterBar = styled.div`
   border-radius: 2em;
-  margin-left: -0.5em;
+  margin-left: 1.5em;
   padding: 1em 0 1em 0;
 `
 const StyledSymbol = styled.span`

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -140,17 +140,24 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId }) => {
                     options.reservesTotal
                   )}  ${symbol.toUpperCase()}`
                 ) : (
-                  <StyledL row justifyContent="flex-start" alignItems="center">
-                    <WarningIcon style={{ color: 'yellow' }} />
-                    <Spacer size="sm" />
-                    <h4>
-                      <Tooltip
-                        text={`This option market has no liquidty, click an option and navigate to the Liquidity tab to initalize trading.`}
-                      >
-                        N/A{' '}
-                      </Tooltip>
-                    </h4>
-                  </StyledL>
+                  <>
+                    <div style={{ minHeight: '.05em' }} />
+                    <StyledL
+                      row
+                      justifyContent="flex-start"
+                      alignItems="center"
+                    >
+                      <WarningIcon style={{ color: 'yellow' }} />
+                      <Spacer size="sm" />
+                      <h4>
+                        <Tooltip
+                          text={`This option market has no liquidty, click an option and navigate to the Liquidity tab to initalize trading.`}
+                        >
+                          N/A{' '}
+                        </Tooltip>
+                      </h4>
+                    </StyledL>
+                  </>
                 )
               ) : (
                 <Loader size="sm" />

--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -172,7 +172,7 @@ const GreyBack = styled.div`
   background: ${(props) => props.theme.color.grey[800]};
   position: absolute;
   z-index: -100;
-  min-height: 338px;
+  min-height: 341px;
   min-width: 1200px;
   left: 0;
 `
@@ -188,6 +188,7 @@ const StyledIcon = styled(LaunchIcon)`
 `
 const StyledHeader = styled.div`
   padding-bottom: ${(props) => props.theme.spacing[4]}px;
+  margin-left: 2em;
 `
 const StyledLink = styled.a`
   text-decoration: none;

--- a/app/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -246,6 +246,6 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
 }
 
 const OptionsContainer = styled.div`
-  border-
+  margin-left: 2em;
 `
 export default OptionsTable

--- a/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableHeader/OptionsTableHeader.tsx
@@ -59,7 +59,7 @@ const GreyBack = styled.div`
   background: ${(props) => props.theme.color.grey[800]};
   position: absolute;
   z-index: -100;
-  min-height: 60px;
+  min-height: 50px;
   min-width: 1200px;
   left: 0;
 `

--- a/app/src/components/PageHeader/PageHeader.tsx
+++ b/app/src/components/PageHeader/PageHeader.tsx
@@ -33,6 +33,7 @@ const StyledIcon = styled.div`
   line-height: 96px;
   text-align: center;
   width: 96px;
+  z-index: -100;
 `
 
 const StyledTitle = styled.h1`

--- a/app/src/components/TableRow/TableRow.tsx
+++ b/app/src/components/TableRow/TableRow.tsx
@@ -29,7 +29,7 @@ const StyledTableRow = styled.div<StyleProps>`
   background-color: ${(props) =>
     props.isActive ? 'transparent' : 'transparent'};
   border-bottom: 1px solid
-    ${(props) => (props.isHead ? 'transparent' : props.theme.color.grey[700])};
+    ${(props) => (props.isHead ? 'transparent' : props.theme.color.grey[800])};
   color: ${(props) => (props.isHead ? props.theme.color.grey[400] : 'inherit')};
   cursor: ${(props) => (props.isHead ? null : 'pointer')};
   display: flex;

--- a/app/src/hooks/user/index.ts
+++ b/app/src/hooks/user/index.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useContext } from 'react'
+import { useRouter } from 'next/router'
 import { useWeb3React } from '@web3-react/core'
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types'
 import { Web3Provider } from '@ethersproject/providers'
@@ -73,15 +74,20 @@ export function useEagerConnect() {
 
 export function useInactiveListener(suppress = false) {
   const { active, error, activate } = useWeb3React()
-
+  const router = useRouter()
   useEffect(() => {
     const { ethereum } = window
 
     const handleChainChanged = () => {
       // eat errors
-      activate(injected, undefined, true).catch((error) => {
-        console.error('Failed to activate after chain changed', error)
-      })
+      activate(injected, undefined, true)
+        .catch((error) => {
+          console.error('Failed to activate after chain changed', error)
+        })
+        .finally(() => {
+          console.log('is this being cahugt')
+          router.reload()
+        })
     }
 
     const handleAccountsChanged = (accounts: string[]) => {

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Provider } from 'react-redux'
-
 import styled, { ThemeProvider, createGlobalStyle } from 'styled-components'
 import { Web3Provider } from '@ethersproject/providers'
 import { Web3ReactProvider, useWeb3React } from '@web3-react/core'

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import Router from 'next/router'
+import { useRouter } from 'next/router'
 import styled from 'styled-components'
 
 import { GetServerSideProps } from 'next'
@@ -11,6 +11,7 @@ import Spacer from '@/components/Spacer'
 import { ADDRESS_FOR_MARKET } from '@/constants/index'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { Grid, Col, Row } from 'react-styled-flexboxgrid'
+import { useClearNotif } from '@/state/notifs/hooks'
 
 import {
   FilterBar,
@@ -38,6 +39,24 @@ const Market = ({ market, data }) => {
   const [expiry, setExpiry] = useState(1609286400)
   const { chainId, active } = useWeb3React()
 
+  const router = useRouter()
+  const clear = useClearNotif()
+  useEffect(() => {
+    const { ethereum } = window
+
+    const handleChainChanged = () => {
+      // eat errors
+      clear(0)
+      router.reload()
+    }
+
+    ethereum.on('chainChanged', handleChainChanged)
+    return () => {
+      if (ethereum.removeListener) {
+        ethereum.removeListener('chainChanged', handleChainChanged)
+      }
+    }
+  })
   const handleFilterType = () => {
     setCallPutActive(!callPutActive)
   }

--- a/app/src/pages/markets/index.tsx
+++ b/app/src/pages/markets/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import PageHeader from '@/components/PageHeader'
 import MarketCards from '@/components/MarketCards'
 import { Grid, Col, Row } from 'react-styled-flexboxgrid'
+import { useClearNotif } from '@/state/notifs/hooks'
 
 const days: { [key: number]: React.ReactNode } = {
   1: (
@@ -89,6 +90,7 @@ const days: { [key: number]: React.ReactNode } = {
 
 const Markets: React.FC = () => {
   const [day, setDay] = useState(0)
+  const clear = useClearNotif()
 
   const isItPiDay = (dateObject) => {
     const date = dateObject.getDate()
@@ -102,6 +104,7 @@ const Markets: React.FC = () => {
   }
   useEffect(() => {
     const date = new Date()
+    clear(0)
     const currentDay = date.getDay()
     if (isItPiDay(date)) {
       setDay(8)

--- a/app/src/state/notifs/hooks.tsx
+++ b/app/src/state/notifs/hooks.tsx
@@ -15,15 +15,27 @@ export const useAddNotif = (): ((
 
   return useCallback(
     (id, title, msg, link) => {
-      if (msg.substr(0, 9) === 'underlying') return
-      dispatch(
-        addNotif({
-          id,
-          title,
-          msg,
-          link,
-        })
-      )
+      if (id === 0) {
+        setTimeout(() => {
+          dispatch(
+            addNotif({
+              id,
+              title,
+              msg,
+              link,
+            })
+          )
+        }, 1000)
+      } else {
+        dispatch(
+          addNotif({
+            id,
+            title,
+            msg,
+            link,
+          })
+        )
+      }
     },
     [dispatch]
   )

--- a/app/src/state/notifs/hooks.tsx
+++ b/app/src/state/notifs/hooks.tsx
@@ -15,6 +15,7 @@ export const useAddNotif = (): ((
 
   return useCallback(
     (id, title, msg, link) => {
+      if (msg.substr(0, 9) === 'underlying') return
       dispatch(
         addNotif({
           id,

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import router from 'next/router'
 import { useDispatch, useSelector } from 'react-redux'
 import { AppDispatch, AppState } from '../index'
 import { updateOptions, OptionsAttributes } from './actions'
@@ -22,7 +23,7 @@ export const useOptions = (): OptionsState => {
 }
 
 export const useUpdateOptions = (): ((assetName: string) => void) => {
-  const { library, chainId } = useActiveWeb3React()
+  const { library, chainId, active } = useActiveWeb3React()
   const addNotif = useAddNotif()
 
   const dispatch = useDispatch<AppDispatch>()
@@ -41,6 +42,11 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
     return Number(breakeven)
   }
 
+  if (!active) {
+    return useCallback(() => {
+      router.push('/markets')
+    }, [router])
+  }
   return useCallback(
     async (assetName: string) => {
       const calls: OptionsAttributes[] = []

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -205,7 +205,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               premium,
                               true
                             )
-
+                            console.log(reserves)
                             calls.push({
                               entity: option,
                               asset: assetName,


### PR DESCRIPTION
Closes #125 
Closes #113 

Changelog
- Improved table styling
- Changing networks now triggers a page reload
- No network detected still throws error, but redirects to `/markets` first
