### PR TITLE
Various style improvements, approval cleanup

### DIFF
--- a/app/src/components/CardContent/CardContent.tsx
+++ b/app/src/components/CardContent/CardContent.tsx
@@ -9,7 +9,7 @@ const StyledCardContent = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
-  padding: ${(props) => props.theme.spacing[3]}px;
+  padding: ${(props) => props.theme.spacing[2]}px;
 `
 
 export default CardContent

--- a/app/src/components/CardTitle/CardTitle.tsx
+++ b/app/src/components/CardTitle/CardTitle.tsx
@@ -11,10 +11,10 @@ const StyledCardTitle = styled.div`
   display: flex;
   font-weight: 700;
   font-size: 18px;
-  padding-top: ${(props) => props.theme.spacing[3]}px;
-  padding-left: ${(props) => props.theme.spacing[4]}px;
-  padding-right: ${(props) => props.theme.spacing[4]}px;
-  padding-bottom: ${(props) => props.theme.spacing[2]}px;
+  padding-top: ${(props) => props.theme.spacing[2]}px;
+  padding-left: ${(props) => props.theme.spacing[3]}px;
+  padding-right: ${(props) => props.theme.spacing[3]}px;
+  padding-bottom: ${(props) => props.theme.spacing[0]}px;
 `
 
 export default CardTitle

--- a/app/src/components/Input/Input.tsx
+++ b/app/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import Spacer from '../Spacer'
@@ -33,10 +33,10 @@ const Input: React.FC<InputProps> = ({
   return (
     <StyledInputWrapper height={height}>
       {!!startAdornment && (
-        <Fragment>
+        <>
           {startAdornment}
           <Spacer size="sm" />
-        </Fragment>
+        </>
       )}
       <StyledInput
         name={name}
@@ -46,16 +46,19 @@ const Input: React.FC<InputProps> = ({
         value={value}
       />
       {!!endAdornment && (
-        <Fragment>
+        <StyledAd>
           <Spacer size="sm" />
           {endAdornment}
           <Spacer size="sm" />
-        </Fragment>
+        </StyledAd>
       )}
     </StyledInputWrapper>
   )
 }
 
+const StyledAd = styled.div`
+  margin-left: -4em;
+`
 interface StyledInputProps {
   height: number
 }

--- a/app/src/components/LineItem/LineItem.tsx
+++ b/app/src/components/LineItem/LineItem.tsx
@@ -36,13 +36,16 @@ const LineItem: React.FC<LineItemProps> = ({ label, data, units }) => {
         <Tooltip text={data.toString()}>
           {sign}
           {currency === '$' ? currency : null} {formatBalance(data)}{' '}
-          {currency !== '$' ? currency : null}
+          <StyledSym>{currency !== '$' ? currency : null}</StyledSym>
         </Tooltip>
       </span>
     </StyledLineItem>
   )
 }
 
+const StyledSym = styled.a`
+  opacity: 0.66;
+`
 const StyledLabel = styled.div`
   color: ${(props) => props.theme.color.grey[400]};
   display: flex;

--- a/app/src/components/LineItem/LineItem.tsx
+++ b/app/src/components/LineItem/LineItem.tsx
@@ -10,9 +10,10 @@ export interface LineItemProps {
   label: React.ReactNode
   data: string | number | any
   units?: any
+  tip?: any
 }
 
-const LineItem: React.FC<LineItemProps> = ({ label, data, units }) => {
+const LineItem: React.FC<LineItemProps> = ({ label, data, units, tip }) => {
   const sign = units
     ? units !== ''
       ? units.toString().charAt(0) === '-'
@@ -33,11 +34,19 @@ const LineItem: React.FC<LineItemProps> = ({ label, data, units }) => {
     <StyledLineItem row justifyContent="space-between" alignItems="center">
       <StyledLabel>{label}</StyledLabel>
       <span>
-        <Tooltip text={data.toString()}>
-          {sign}
-          {currency === '$' ? currency : null} {formatBalance(data)}{' '}
-          <StyledSym>{currency !== '$' ? currency : null}</StyledSym>
-        </Tooltip>
+        {tip ? (
+          <Tooltip text={tip}>
+            {sign}
+            {currency === '$' ? currency : null} {formatBalance(data)}{' '}
+            <StyledSym>{currency !== '$' ? currency : null}</StyledSym>
+          </Tooltip>
+        ) : (
+          <>
+            {sign}
+            {currency === '$' ? currency : null} {formatBalance(data)}{' '}
+            <StyledSym>{currency !== '$' ? currency : null}</StyledSym>
+          </>
+        )}
       </span>
     </StyledLineItem>
   )

--- a/app/src/components/Market/BalanceCard/index.tsx
+++ b/app/src/components/Market/BalanceCard/index.tsx
@@ -13,18 +13,19 @@ import mintTestTokens from '@/utils/mintTestTokens'
 import { useTransactionAdder } from '@/state/transactions/hooks'
 import { useOptions } from '@/state/options/hooks'
 import { usePositions } from '@/state/positions/hooks'
-import { Operation } from '@/constants/index'
+import { Operation, STABLECOINS } from '@/constants/index'
 import numeral from 'numeral'
 import formatEtherBalance from '@/utils/formatEtherBalance'
 import formatBalance from '@/utils/formatBalance'
+import useTokenBalance from '@/hooks/useTokenBalance'
 
 import { formatEther } from 'ethers/lib/utils'
 const BalanceCard: React.FC = () => {
   const { loading, balance } = usePositions()
   const { calls, puts } = useOptions()
   const addTransaction = useTransactionAdder()
-
   const { library, account, chainId } = useWeb3React()
+  const daiBal = useTokenBalance(STABLECOINS[chainId].address)
 
   const handleMintTestTokens = async () => {
     const now = () => new Date().getTime()
@@ -55,8 +56,10 @@ const BalanceCard: React.FC = () => {
   if (loading) return null
   if (calls.length === 0) return null
   return (
-    <Card border>
+    <Card>
       <CardContent>
+        <LineItem label={`DAI Balance`} data={daiBal} />
+        <Spacer size="sm" />
         <LineItem
           label={`${balance.asset.symbol} Balance`}
           data={formatEther(balance.quantity)}

--- a/app/src/components/Market/OptionsTable/NewMarketRow/NewMarketRow.tsx
+++ b/app/src/components/Market/OptionsTable/NewMarketRow/NewMarketRow.tsx
@@ -12,9 +12,9 @@ export interface NewMarketRowProps {
 const NewMarketRow: React.FC<NewMarketRowProps> = ({ onClick }) => {
   return (
     <>
-      <TableRow isHead onClick={onClick}>
+      <TableRow isHead>
         <TableCell></TableCell>
-        <StyledButtonCellError key={'Open'}>
+        <StyledButtonCellError key={'Open'} onClick={onClick}>
           <AddIcon />
           <Spacer size="md" />
           Add a New Option Market
@@ -33,7 +33,7 @@ const StyledButtonCellError = styled.div`
   font-weight: inherit;
   color: ${(props) => props.theme.color.white};
   margin-right: ${(props) => props.theme.spacing[2]}px;
-  width: 100%;
+  width: 40%;
 `
 
 export default NewMarketRow

--- a/app/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -247,5 +247,6 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
 
 const OptionsContainer = styled.div`
   margin-left: 2em;
+  margin-top: -0.2em;
 `
 export default OptionsTable

--- a/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
@@ -67,6 +67,7 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
   const nodeRef = useClickAway(() => {
     setToggle(false)
   })
+
   return (
     <StyledDiv ref={nodeRef}>
       <TableRow
@@ -80,9 +81,13 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
         key={key}
         onClick={handleOnClick}
       >
-        <TableCell>${strike}</TableCell>
+        <TableCell>{numeral(strike).format('$0.00a')}</TableCell>
         <TableCell>
-          {premium !== '0.00' ? <>{`$${breakeven}`}</> : <>{`--`}</>}
+          {premium !== '0.00' ? (
+            <>{numeral(breakeven).format('$0.00a')}</>
+          ) : (
+            <>{`-`}</>
+          )}
         </TableCell>
         {premium !== '0.00' ? (
           <TableCell>
@@ -104,7 +109,7 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
         ) : (
           <TableCell>-</TableCell>
         )}
-        {reserves[0] !== '0.00' ? (
+        {parseInt(reserves[1]) > 0 ? (
           <TableCell>
             <StyledR>
               <StyledT>

--- a/app/src/components/Market/OrderCard/OrderCard.tsx
+++ b/app/src/components/Market/OrderCard/OrderCard.tsx
@@ -84,7 +84,7 @@ const OrderCard: React.FC<OrderProps> = ({ orderState }) => {
           </StyledTitle>
           <Reverse />
           <StyledTitle>
-            {`$${formatBalance(item.strike)} ${month}/${date} ${year}`}
+            {`$${formatBalance(item.strike)} ${month}/${date}/${year}`}
           </StyledTitle>
         </div>
         <Spacer />

--- a/app/src/components/Market/OrderCard/OrderCard.tsx
+++ b/app/src/components/Market/OrderCard/OrderCard.tsx
@@ -7,6 +7,7 @@ import ClearIcon from '@material-ui/icons/Clear'
 
 import Button from '@/components/Button'
 import Spacer from '@/components/Spacer'
+import ErrorBoundary from '@/components/ErrorBoundary'
 
 import Box from '@/components/Box'
 import Card from '@/components/Card'
@@ -75,31 +76,39 @@ const OrderCard: React.FC<OrderProps> = ({ orderState }) => {
     removeItem()
   }
   return (
-    <Card border>
-      <Box row justifyContent="space-between" alignItems="center">
-        <StyledLogo src={getIconForMarket(item.asset.toLowerCase())} alt={''} />
-        <div>
-          <StyledTitle>
-            {`${item.asset} ${item.entity.isCall ? 'Call' : 'Put'}`}
-          </StyledTitle>
+    <>
+      <Spacer size="sm" />
+      <Card border>
+        <Box row justifyContent="space-between" alignItems="center">
+          <StyledLogo
+            src={getIconForMarket(item.asset.toLowerCase())}
+            alt={''}
+          />
+          <div>
+            <StyledTitle>
+              {`${item.asset} ${item.entity.isCall ? 'Call' : 'Put'}`}
+            </StyledTitle>
+            <Reverse />
+            <StyledTitle>
+              {`$${formatBalance(item.strike)} ${month}/${date}/${year}`}
+            </StyledTitle>
+          </div>
+          <Spacer />
+          <CustomButton>
+            <Button variant="transparent" size="sm" onClick={() => clear()}>
+              <ClearIcon />
+            </Button>
+          </CustomButton>
+        </Box>
+        <CardContent>
+          <Spacer size="sm" />
           <Reverse />
-          <StyledTitle>
-            {`$${formatBalance(item.strike)} ${month}/${date}/${year}`}
-          </StyledTitle>
-        </div>
-        <Spacer />
-        <CustomButton>
-          <Button variant="transparent" size="sm" onClick={() => clear()}>
-            <ClearIcon />
-          </Button>
-        </CustomButton>
-      </Box>
-      <CardContent>
-        <Spacer size="sm" />
-        <Reverse />
-        <OrderContent />
-      </CardContent>
-    </Card>
+          <ErrorBoundary fallback={<span>ORDER ERROR</span>}>
+            <OrderContent />
+          </ErrorBoundary>
+        </CardContent>
+      </Card>
+    </>
   )
 }
 

--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -26,6 +26,7 @@ import { UNISWAP_ROUTER02_V2 } from '@/lib/constants'
 import ArrowBackIcon from '@material-ui/icons/ArrowBack'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ExpandLessIcon from '@material-ui/icons/ExpandLess'
+import AddIcon from '@material-ui/icons/Add'
 
 import {
   useItem,
@@ -54,6 +55,8 @@ const AddLiquidity: React.FC = () => {
     primary: '',
     secondary: '',
   })
+  // set null lp
+  const [hasLiquidity, setHasL] = useState(false)
   // web3
   const { library, chainId } = useWeb3React()
   // approval
@@ -71,11 +74,10 @@ const AddLiquidity: React.FC = () => {
     new Token(entity.chainId, entity.assetAddresses[2], 18, 'SHORT')
   ).data
 
-  const hasLiquidity = lpPair
-    ? lpPair.reserve0.greaterThan('0')
-      ? true
-      : false
-    : false
+  useEffect(() => {
+    setHasL(lpPair ? (lpPair.reserve0.greaterThan('0') ? true : false) : false)
+  }, [lpPair, setHasL])
+
   const lpToken = lpPair ? lpPair.liquidityToken.address : ''
   const token0 = lpPair ? lpPair.token0.symbol : ''
   const token1 = lpPair ? lpPair.token1.symbol : ''
@@ -338,9 +340,9 @@ const AddLiquidity: React.FC = () => {
             onChange={handleInputChange}
             onClick={() => console.log('Max unavailable.')} //
           />
-          <Spacer />
-          <StyledText>Per</StyledText>
-          <Spacer />
+          <StyledAdd>
+            <AddIcon />
+          </StyledAdd>
           <PriceInput
             name="secondary"
             title={`Underlyings Input`}
@@ -370,7 +372,7 @@ const AddLiquidity: React.FC = () => {
         data={caculatePoolShare()}
         units={`% of the Pool.`}
       />
-      <Spacer />
+      <Spacer size="sm" />
       <IconButton
         text="Advanced"
         variant="transparent"
@@ -378,7 +380,7 @@ const AddLiquidity: React.FC = () => {
       >
         {advanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
       </IconButton>
-      <Spacer />
+      <Spacer size="sm" />
 
       {advanced ? (
         <>
@@ -448,6 +450,12 @@ const AddLiquidity: React.FC = () => {
   )
 }
 
+const StyledAdd = styled.div`
+  color: ${(props) => props.theme.color.grey[400]};
+  display: flex;
+  justify-content: center;
+  margin: 0.7em;
+`
 const StyledText = styled.h5`
   color: ${(props) => props.theme.color.white};
   display: flex;

--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -83,7 +83,6 @@ const AddLiquidity: React.FC = () => {
   const lp = useTokenBalance(lpToken)
   const lpTotalSupply = useTokenTotalSupply(lpToken)
   const spender = UNISWAP_CONNECTOR[chainId]
-  console.log(item.entity.assetAddresses[0])
   const tokenAllowance = useTokenAllowance(
     item.entity.assetAddresses[0],
     spender
@@ -272,7 +271,6 @@ const AddLiquidity: React.FC = () => {
         parseEther(inputs.primary || '0')
       )
 
-      console.log(parseEther(tokenAllowance).toString())
       if (approve) {
         console.log('CHANGE?')
         updateItem(item, orderType, loading, approve)

--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -75,8 +75,10 @@ const AddLiquidity: React.FC = () => {
   ).data
 
   useEffect(() => {
-    setHasL(lpPair ? (lpPair.reserve0.greaterThan('0') ? true : false) : false)
-  }, [lpPair, setHasL])
+    console.log('triggered')
+    console.log(item.reserves[0].toString())
+    setHasL(parseInt(item.reserves[0].toString()) > 0 ? true : false)
+  }, [item])
 
   const lpToken = lpPair ? lpPair.liquidityToken.address : ''
   const token0 = lpPair ? lpPair.token0.symbol : ''
@@ -274,7 +276,6 @@ const AddLiquidity: React.FC = () => {
       )
 
       if (approve) {
-        console.log('CHANGE?')
         updateItem(item, orderType, loading, approve)
       }
     }
@@ -315,8 +316,7 @@ const AddLiquidity: React.FC = () => {
           <Tooltip text={title.tip}>{title.text}</Tooltip>
         </StyledTitle>
       </Box>
-
-      <Spacer />
+      <Spacer size="sm" />
       {hasLiquidity ? (
         <PriceInput
           name="primary"
@@ -350,7 +350,7 @@ const AddLiquidity: React.FC = () => {
             onChange={handleInputChange}
             onClick={() => console.log('Max unavailable.')} //
             balance={underlyingAmount}
-          />{' '}
+          />
         </>
       )}
 
@@ -382,7 +382,7 @@ const AddLiquidity: React.FC = () => {
       </IconButton>
       <Spacer size="sm" />
 
-      {advanced ? (
+      {advanced && hasLiquidity ? (
         <>
           <Spacer size="sm" />
           <LineItem

--- a/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
+++ b/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
@@ -30,27 +30,6 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
       : 'SHORT'
   return (
     <>
-      <Spacer size="sm" />
-      <Box row justifyContent="space-between" alignItems="center">
-        <Label text={'Reserves'} />
-        <Spacer />
-        <StyledR>
-          <StyledT>
-            {reserve0Units === item.asset.toUpperCase()
-              ? formatEtherBalance(item.reserves[0].toString())
-              : formatEtherBalance(item.reserves[1].toString())}{' '}
-            <Units>{item.asset.toUpperCase()}</Units>
-          </StyledT>
-          <Spacer size="sm" />
-          <span>
-            {reserve0Units === item.asset.toUpperCase()
-              ? formatEtherBalance(item.reserves[1].toString())
-              : formatEtherBalance(item.reserves[0].toString())}{' '}
-            <Units>SHORT</Units>
-          </span>
-        </StyledR>
-      </Box>
-
       <Spacer />
       <LineItem
         label={'LP Balance'}
@@ -59,16 +38,17 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
       />
       <Spacer />
       <Box row justifyContent="center" alignItems="center">
-        <Button size="sm" onClick={() => change(Operation.ADD_LIQUIDITY)}>
+        <Button full size="sm" onClick={() => change(Operation.ADD_LIQUIDITY)}>
           Provide
         </Button>
         <Spacer />
         {!balance ? (
-          <Button size="sm" variant="secondary" disabled>
+          <Button full size="sm" variant="secondary" disabled>
             Withdraw
           </Button>
         ) : (
           <Button
+            full
             size="sm"
             variant="secondary"
             onClick={() => change(Operation.REMOVE_LIQUIDITY_CLOSE)}
@@ -116,19 +96,23 @@ const OrderOptions: React.FC = () => {
           <Spacer />
           <TabPanel>
             <StyledColumn>
+              <Spacer />
               <Box row justifyContent="flex-start" alignItems="center">
-                <Label text={'Long Balance'} />
-                <Spacer />
-                <StyledBalance>
-                  {positions.loading ? (
-                    <Loader size="sm" />
-                  ) : !option.long ? (
-                    '0.00'
-                  ) : (
-                    formatEtherBalance(option.long)
-                  )}
-                </StyledBalance>
+                {!positions.loading ? (
+                  <LineItem
+                    label={'Long Balance'}
+                    data={
+                      option.long
+                        ? formatEtherBalance(option.long).toString()
+                        : '0'
+                    }
+                    units={'LONG'}
+                  />
+                ) : (
+                  <Loader size="sm" />
+                )}
               </Box>
+              <Spacer />
               <Box row justifyContent="space-between" alignItems="center">
                 <Button full size="sm" onClick={() => change(Operation.LONG)}>
                   Buy
@@ -148,19 +132,23 @@ const OrderOptions: React.FC = () => {
           </TabPanel>
           <TabPanel>
             <StyledColumn>
+              <Spacer />
               <Box row justifyContent="flex-start" alignItems="center">
-                <Label text={'Short Balance'} />
-                <Spacer />
-                <StyledBalance>
-                  {positions.loading ? (
-                    <Loader size="sm" />
-                  ) : !option.short ? (
-                    '0.00'
-                  ) : (
-                    formatEtherBalance(option.short)
-                  )}
-                </StyledBalance>
+                {!positions.loading ? (
+                  <LineItem
+                    label={'Short Balance'}
+                    data={
+                      option.long
+                        ? formatEtherBalance(option.short).toString()
+                        : '0'
+                    }
+                    units={'SHORT'}
+                  />
+                ) : (
+                  <Loader size="sm" />
+                )}
               </Box>
+              <Spacer />
               <Box row justifyContent="space-between" alignItems="center">
                 <Button full size="sm" onClick={() => change(Operation.SHORT)}>
                   Buy

--- a/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
+++ b/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
@@ -138,7 +138,7 @@ const OrderOptions: React.FC = () => {
                   <LineItem
                     label={'Short Balance'}
                     data={
-                      option.long
+                      option.short
                         ? formatEtherBalance(option.short).toString()
                         : '0'
                     }
@@ -156,7 +156,13 @@ const OrderOptions: React.FC = () => {
                 <Spacer />
                 <Button
                   full
-                  disabled={!positions.loading ? false : true}
+                  disabled={
+                    option.short
+                      ? formatEtherBalance(option.short).toString() !== '0.00'
+                        ? false
+                        : true
+                      : true
+                  }
                   size="sm"
                   variant="secondary"
                   onClick={() => change(Operation.CLOSE_SHORT)}

--- a/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react'
+import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 
 import Box from '@/components/Box'
@@ -278,7 +278,7 @@ const AddLiquidity: React.FC = () => {
   }
 
   // FIX
-  const isLpApproved = useCallback(() => {
+  const isLpApproved = useMemo(() => {
     const approved: boolean = parseEther(tokenAllowance).gt(
       parseEther(inputs.primary || '0')
     )
@@ -286,7 +286,7 @@ const AddLiquidity: React.FC = () => {
     return approved
   }, [inputs, tokenAllowance, setLpApproved])
 
-  const isOptionApproved = useCallback(() => {
+  const isOptionApproved = useMemo(() => {
     const approved: boolean = parseEther(optionAllowance).gt(
       parseEther(calculateLiquidityValuePerShare().shortPerLp || '0')
     )
@@ -294,22 +294,6 @@ const AddLiquidity: React.FC = () => {
     return approved
   }, [setOptionApproved, optionAllowance, calculateLiquidityValuePerShare])
 
-  useEffect(() => {
-    const lpApproved: boolean = isLpApproved()
-    const optionApproved: boolean = isOptionApproved()
-    if (lpApproved && optionApproved) {
-      updateItem(item, orderType, loading, true)
-    }
-  }, [
-    updateItem,
-    item,
-    loading,
-    orderType,
-    isLpApproved,
-    isOptionApproved,
-    tokenAllowance,
-    optionAllowance,
-  ])
   // END FIX
 
   return (
@@ -344,24 +328,31 @@ const AddLiquidity: React.FC = () => {
 
       <Box row justifyContent="flex-start">
         <Button
+          variant="secondary"
           text="25%"
           onClick={() => {
             handleRatio(250)
           }}
         />
+        <div style={{ width: '5px' }} />
         <Button
+          variant="secondary"
           text="50%"
           onClick={() => {
             handleRatio(500)
           }}
         />
+        <div style={{ width: '5px' }} />
         <Button
+          variant="secondary"
           text="75%"
           onClick={() => {
             handleRatio(750)
           }}
         />
+        <div style={{ width: '5px' }} />
         <Button
+          variant="secondary"
           text="100%"
           onClick={() => {
             handleRatio(1000)

--- a/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -38,6 +38,7 @@ import { useAddNotif } from '@/state/notifs/hooks'
 
 import { useWeb3React } from '@web3-react/core'
 import { Token, TokenAmount } from '@uniswap/sdk'
+import numeral from 'numeral'
 
 const AddLiquidity: React.FC = () => {
   // executes transactions
@@ -326,14 +327,13 @@ const AddLiquidity: React.FC = () => {
           <Tooltip text={title.tip}>{title.text}</Tooltip>
         </StyledTitle>
       </Box>
-
       <Spacer />
-
-      <Box row alignItems="center">
-        <Label text={`Amount`} />
-        <Spacer size="md" />
-        <StyledRatio>{Math.round(10 * (ratio / 10)) / 10 + '%'}</StyledRatio>
-      </Box>
+      <LineItem
+        label={'Amount'}
+        data={Math.round(10 * (ratio / 10)) / 10 + '%'}
+        units={'%'}
+      ></LineItem>
+      <Spacer size="sm" />
       <Slider
         min={1}
         max={1000}
@@ -372,16 +372,16 @@ const AddLiquidity: React.FC = () => {
       <Spacer />
       <LineItem
         label="This requires"
-        data={`${calculateBurn()}`}
+        data={`${numeral(calculateBurn()).format('0.00')}`}
         units={`UNI-V2 LP`}
       />
       <Spacer />
       <LineItem
         label="You will receive"
-        data={calculateUnderlyingOutput()}
+        data={numeral(calculateUnderlyingOutput()).format('0.00')}
         units={`${item.asset.toUpperCase()}`}
       />
-      <Spacer />
+      <Spacer size="sm" />
       <IconButton
         text="Advanced"
         variant="transparent"
@@ -389,7 +389,7 @@ const AddLiquidity: React.FC = () => {
       >
         {advanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
       </IconButton>
-      <Spacer />
+      <Spacer size="sm" />
 
       {advanced ? (
         <>

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -211,7 +211,6 @@ const Swap: React.FC = () => {
         onClick={handleSetMax}
         balance={tokenAmount}
       />
-
       <Spacer />
       <LineItem
         label={`Total ${

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -60,7 +60,7 @@ const Swap: React.FC = () => {
     entity.chainId,
     entity.assetAddresses[0],
     18,
-    item.asset.toUpperCase()
+    entity.isPut ? 'DAI' : item.asset.toUpperCase()
   )
 
   let title = { text: '', tip: '' }
@@ -193,13 +193,13 @@ const Swap: React.FC = () => {
         <LineItem
           label="Short Option Premium"
           data={formatEther(item.shortPremium)}
-          units={item.asset}
+          units={entity.isPut ? 'DAI' : item.asset}
         />
       ) : (
         <LineItem
           label="Option Premium"
           data={formatEther(item.premium)}
-          units={item.asset}
+          units={entity.isPut ? 'DAI' : item.asset}
         />
       )}
       <Spacer />
@@ -230,7 +230,7 @@ const Swap: React.FC = () => {
               orderType === Operation.CLOSE_SHORT
             ? '+'
             : '-'
-        } ${item.asset.toUpperCase()}`}
+        } ${entity.isPut ? 'DAI' : item.asset.toUpperCase()}`}
       />
       <Spacer size="sm" />
       <IconButton

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -123,6 +123,7 @@ const Swap: React.FC = () => {
     const max = Math.round(
       ((+underlyingTokenBalance / (+item.premium + Number.EPSILON)) * 100) / 100
     )
+    console.log(max)
     setInputs({ ...inputs, primary: max.toString() })
   }
 
@@ -154,7 +155,6 @@ const Swap: React.FC = () => {
   //APPROVALS
   useEffect(() => {
     if (parseInt(tokenAllowance) > 0) {
-      console.log(tokenAllowance)
       const approve: boolean = parseEther(tokenAllowance).gt(
         parseEther(inputs.primary || '0')
       )

--- a/app/src/components/Market/PositionsCard/PositionsCard.tsx
+++ b/app/src/components/Market/PositionsCard/PositionsCard.tsx
@@ -187,7 +187,7 @@ const StyledPrices = styled(Box)`
   padding: 0 1em 0 1em;
 `
 const StyledTitle = styled.h3`
-  color: ${(props) => props.theme.color.grey[400]};
+  color: ${(props) => props.theme.color.white};
   display: flex;
   flex-direction: row;
   justify-content: flex-start;

--- a/app/src/components/Market/PositionsCard/PositionsCard.tsx
+++ b/app/src/components/Market/PositionsCard/PositionsCard.tsx
@@ -11,6 +11,8 @@ import { Protocol } from '@/lib/protocol'
 
 import { useWeb3React } from '@web3-react/core'
 
+import Table from '@/components/Table'
+import TableRow from '@/components/TableRow'
 import Card from '@/components/Card'
 import CardContent from '@/components/CardContent'
 import CardTitle from '@/components/CardTitle'
@@ -52,29 +54,19 @@ const Position: React.FC<TokenProps> = ({ option }) => {
 
   return (
     <StyledPosition onClick={handleClick}>
+      <Spacer />
       <Box row justifyContent="flex-start" alignItems="center">
         <Spacer size="sm" />
-        <StyledLogo
-          src={getIconForMarket(option.attributes.asset.toLowerCase())}
-          alt={''}
-        />
-        <Spacer />
-        <div>
-          <Spacer />
+        <Box row justifyContent="space-between" alignItems="center">
           <StyledTitle>
             {`${option.attributes.asset} ${
               option.attributes.entity.isCall ? 'Call' : 'Put'
-            }`}
-          </StyledTitle>
-          <Reverse />
-          <StyledTitle>
+            } `}
             {`${numeral(option.attributes.strike).format(
               '$0.00a'
             )} ${month}/${date}/${year}`}
           </StyledTitle>
-        </div>
-
-        <Spacer size="sm" />
+        </Box>
       </Box>
       <StyledPrices row justifyContent="space-between" alignItems="center">
         <StyledPrice>
@@ -131,11 +123,10 @@ const PositionsCard: React.FC = () => {
         <Reverse />
         <CardTitle>
           <div onClick={() => setOpen(!open)}>
-            <StyledBox row justifyContent="space-around" alignItems="center">
+            <StyledBox row justifyContent="space-between" alignItems="center">
               <Title>{`Active Positions (${positions.options.length})`}</Title>
-              <IconButton variant="tertiary">
-                {!open ? <ExpandMoreIcon /> : <ExpandLessIcon />}
-              </IconButton>
+              <Spacer />
+              {!open ? <ExpandMoreIcon /> : <ExpandLessIcon />}
             </StyledBox>
           </div>
         </CardTitle>
@@ -143,18 +134,25 @@ const PositionsCard: React.FC = () => {
         {!open ? (
           <Spacer size="sm" />
         ) : (
-          <>
+          <Scroll>
             <CardContent>
               {positions.options.map((pos, i) => {
                 return <Position key={i} option={pos} />
               })}
             </CardContent>
-          </>
+          </Scroll>
         )}
       </Card>
     </div>
   )
 }
+
+const Scroll = styled.div`
+  overflow: scroll;
+  height: 20em;
+  border-radius: ${(props) => props.theme.borderRadius}px;
+  background: ${(props) => props.theme.color.grey[800]};
+`
 
 const StyledBox = styled(Box)`
   cursor: pointer;
@@ -189,28 +187,24 @@ const StyledPrices = styled(Box)`
   padding: 0 1em 0 1em;
 `
 const StyledTitle = styled.h3`
-  color: ${(props) => props.theme.color.white};
+  color: ${(props) => props.theme.color.grey[400]};
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   margin-top: -0.5em;
+  margin-bottom: 0em;
 `
 const StyledPosition = styled.a`
-  border: 1px solid ${(props) => props.theme.color.grey[800]};
+  border: 1.5px solid ${(props) => props.theme.color.grey[800]};
   border-radius: ${(props) => props.theme.borderRadius}px;
-  background: ${(props) => props.theme.color.black};
   min-height: 2em;
   border-radius: 4px;
-  padding-left: 0.8em;
-  padding-right: 0.8em;
-  padding-bottom: 1em;
-  padding-top: 0.5em;
   cursor: pointer;
-  margin-bottom: 0.5em;
-  margin-top: 0.5em;
+  margin-bottom: 0.3em;
+  margin-top: -0.3em;
+  padding: 0 0.5em 0.5em 0.5em;
   &:hover {
-    background: ${(props) => props.theme.color.grey[800]};
-    border: 1.5px solid ${(props) => props.theme.color.grey[600]};
+    background: ${(props) => props.theme.color.black};
   }
 `
 const StyledLink = styled.a`

--- a/app/src/components/Market/PositionsCard/PositionsCard.tsx
+++ b/app/src/components/Market/PositionsCard/PositionsCard.tsx
@@ -34,6 +34,7 @@ import formatEtherBalance from '@/utils/formatEtherBalance'
 import formatExpiry from '@/utils/formatExpiry'
 import LineItem from '@/components/LineItem'
 import { useClickAway } from '@/hooks/utils/useClickAway'
+import numeral from 'numeral'
 export interface TokenProps {
   option: any // replace with option type
 }
@@ -51,7 +52,7 @@ const Position: React.FC<TokenProps> = ({ option }) => {
 
   return (
     <StyledPosition onClick={handleClick}>
-      <Box row justifyContent="space-around" alignItems="center">
+      <Box row justifyContent="flex-start" alignItems="center">
         <Spacer size="sm" />
         <StyledLogo
           src={getIconForMarket(option.attributes.asset.toLowerCase())}
@@ -67,22 +68,14 @@ const Position: React.FC<TokenProps> = ({ option }) => {
           </StyledTitle>
           <Reverse />
           <StyledTitle>
-            {`$${option.attributes.strike} ${month}/${date} ${year}`}
+            {`${numeral(option.attributes.strike).format(
+              '$0.00a'
+            )} ${month}/${date}/${year}`}
           </StyledTitle>
         </div>
-        <Spacer />
-        <StyledLink
-          href={`${baseUrl}/${option.attributes.address}`}
-          target="_blank"
-        >
-          {option.attributes.address.length > 0
-            ? option.attributes.address.substr(0, 4) + '...'
-            : '-'}
-          <LaunchIcon style={{ fontSize: '14px' }} />
-        </StyledLink>
+
         <Spacer size="sm" />
       </Box>
-      <Spacer size="sm" />
       <StyledPrices row justifyContent="space-between" alignItems="center">
         <StyledPrice>
           <StyledT>Long</StyledT>
@@ -216,8 +209,8 @@ const StyledPosition = styled.a`
   margin-bottom: 0.5em;
   margin-top: 0.5em;
   &:hover {
-    background: ${(props) => props.theme.color.grey[600]};
-    border: 1.5px solid ${(props) => props.theme.color.grey[400]};
+    background: ${(props) => props.theme.color.grey[800]};
+    border: 1.5px solid ${(props) => props.theme.color.grey[600]};
   }
 `
 const StyledLink = styled.a`

--- a/app/src/components/Market/TransactionCard/TransactionCard.tsx
+++ b/app/src/components/Market/TransactionCard/TransactionCard.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useCallback, useState } from 'react'
 import styled from 'styled-components'
 
 import Box from '@/components/Box'
 import IconButton from '@/components/Button'
+import Button from '@/components/Button'
 import Card from '@/components/Card'
 import CardContent from '@/components/CardContent'
 import CardTitle from '@/components/CardTitle'
@@ -13,10 +14,10 @@ import TableBody from '@/components/TableBody'
 import Spacer from '@/components/Spacer'
 import Loader from '@/components/Loader'
 import LaunchIcon from '@material-ui/icons/Launch'
-
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import ExpandLessIcon from '@material-ui/icons/ExpandLess'
 import { useWeb3React } from '@web3-react/core'
 import ClearIcon from '@material-ui/icons/Clear'
-
 import LitContainer from '@/components/LitContainer'
 import TableCell from '@/components/TableCell'
 
@@ -24,6 +25,7 @@ import {
   useAllTransactions,
   useClearTransactions,
 } from '@/state/transactions/hooks'
+import { useClickAway } from '@/hooks/utils/useClickAway'
 
 const ETHERSCAN_MAINNET = 'https://etherscan.io/tx/'
 const ETHERSCAN_RINKEBY = 'https://rinkeby.etherscan.io/tx/'
@@ -32,100 +34,127 @@ const TransactionCard: React.FC = () => {
   const txs = useAllTransactions()
   const clearAll = useClearTransactions()
   const { library, chainId } = useWeb3React()
+  const [open, setOpen] = useState(false)
+  const [first, setFirst] = useState(null)
+
   const clear = () => {
     clearAll()
   }
+  const nodeRef = useClickAway(() => {
+    setOpen(false)
+  })
 
+  useEffect(() => {
+    if (txs) {
+      Object.keys(txs).map((hash, i) => {
+        setFirst(hash)
+      })
+    }
+  }, [txs, setFirst])
   if (!txs) return null
+
   if (Object.keys(txs).length === 0 && txs.constructor === Object) return null
   return (
-    <>
+    <div ref={nodeRef}>
       <Card border>
+        <Spacer size="sm" />
         <CardTitle>
-          <Box row justifyContent="space-around" alignItems="center">
-            <StyledTitle>Recent Transactions</StyledTitle>
-            <IconButton variant="transparent" size="sm" onClick={() => clear()}>
-              <ClearIcon />
-            </IconButton>
-          </Box>
+          <div onClick={() => setOpen(!open)}>
+            <StyledBox row justifyContent="space-between" alignItems="center">
+              <StyledTitle>
+                Recent Transactions
+                <Spacer />
+                {txs[first]?.receipt ? null : <Loader size="sm" />}
+              </StyledTitle>
+              <Spacer />
+              {!open ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+            </StyledBox>
+          </div>
         </CardTitle>
-        <div style={{ marginTop: '-1em' }} />
-        <CardContent>
-          <StyledContainer>
-            <Table>
-              <TableRow isHead>
-                <TableCell>Time</TableCell>
-                <TableCell>Type</TableCell>
-                <TableCell>Hash</TableCell>
-                <TableCell>Status</TableCell>
-              </TableRow>
-              <div style={{ marginTop: '-1em' }} />
-              {Object.keys(txs)
-                .reverse()
-                .map((hash, i) => {
-                  const date = new Date(txs[hash].confirmedTime)
-                  return (
-                    <StyledTableRow isHead key={i}>
-                      <TableCell>
-                        {!txs[hash].receipt ? (
-                          <Loader size="sm" />
-                        ) : (
-                          <StyledDate>
-                            {date.toUTCString().substr(16, 10)}
-                          </StyledDate>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        {txs[hash].summary ? (
-                          <StyledText>
-                            <Tooltip text={txs[hash].summary.type}>
+        <Spacer size="sm" />
+        {open ? (
+          <CardContent>
+            <Button variant="secondary" onClick={() => clear()}>
+              Clear All
+            </Button>
+            <StyledContainer>
+              <Table>
+                <TableRow isHead>
+                  <TableCell>Time</TableCell>
+                  <TableCell>Type</TableCell>
+                  <TableCell>Hash</TableCell>
+                  <TableCell>Status</TableCell>
+                </TableRow>
+                <div style={{ marginTop: '-1em' }} />
+                {Object.keys(txs)
+                  .reverse()
+                  .map((hash, i) => {
+                    const date = new Date(txs[hash].confirmedTime)
+                    const start = new Date(txs[hash].addedTime)
+                    return (
+                      <StyledTableRow isHead key={i}>
+                        <TableCell>
+                          {!txs[hash].receipt ? (
+                            <StyledDate>
+                              {start.toUTCString().substr(16, 10)}
+                            </StyledDate>
+                          ) : (
+                            <StyledDate>
+                              {date.toUTCString().substr(16, 10)}
+                            </StyledDate>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {txs[hash].summary ? (
+                            <StyledText>
                               {txs[hash].summary.type.substr(0, 8)}
-                            </Tooltip>
-                          </StyledText>
-                        ) : !txs[hash].approval.tokenAddress ? null : (
-                          <StyledText>APPROVE</StyledText>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <StyledLink
-                          href={`${
-                            chainId !== 4
-                              ? ETHERSCAN_MAINNET
-                              : ETHERSCAN_RINKEBY
-                          }${txs[hash].hash}`}
-                          target="__blank"
-                        >
-                          <Box
-                            row
-                            justifyContent="flex-start"
-                            alignItems="center"
+                            </StyledText>
+                          ) : !txs[hash].approval.tokenAddress ? null : (
+                            <StyledText>APPROVE</StyledText>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <StyledLink
+                            href={`${
+                              chainId !== 4
+                                ? ETHERSCAN_MAINNET
+                                : ETHERSCAN_RINKEBY
+                            }${txs[hash].hash}`}
+                            target="__blank"
                           >
-                            {txs[hash].hash.substr(0, 4)}...
-                            <LaunchIcon style={{ fontSize: '14px' }} />
-                          </Box>
-                        </StyledLink>
-                      </TableCell>
-                      <TableCell>
-                        {!txs[hash].receipt ? (
-                          <StyledPending>Pending</StyledPending>
-                        ) : (
-                          <StyledConfirmed>Confirmed</StyledConfirmed>
-                        )}
-                      </TableCell>
-                    </StyledTableRow>
-                  )
-                })}
-            </Table>
-          </StyledContainer>
-          <div style={{ marginTop: '-1em' }} />
-        </CardContent>
+                            <Box
+                              row
+                              justifyContent="flex-start"
+                              alignItems="center"
+                            >
+                              {txs[hash].hash.substr(0, 4)}...
+                              <LaunchIcon style={{ fontSize: '14px' }} />
+                            </Box>
+                          </StyledLink>
+                        </TableCell>
+                        <TableCell>
+                          {!txs[hash].receipt ? (
+                            <StyledPending>Pending</StyledPending>
+                          ) : (
+                            <StyledConfirmed>Confirmed</StyledConfirmed>
+                          )}
+                        </TableCell>
+                      </StyledTableRow>
+                    )
+                  })}
+              </Table>
+            </StyledContainer>
+            <div style={{ marginTop: '-1em' }} />
+          </CardContent>
+        ) : null}
+        <Spacer size="sm" />
       </Card>
-    </>
+    </div>
   )
 }
 
-const Reverse = styled.div`
-  margin-top: -1.1em;
+const StyledBox = styled(Box)`
+  cursor: pointer;
 `
 
 const StyledContainer = styled.div`
@@ -157,8 +186,7 @@ const StyledTitle = styled(Box)`
   align-items: center;
   display: flex;
   flex-direction: row;
-  min-width: 15.7em;
-  width: 100%;
+  min-width: 16em;
 `
 
 const StyledConfirmed = styled.h5`

--- a/app/src/components/PriceInput/PriceInput.tsx
+++ b/app/src/components/PriceInput/PriceInput.tsx
@@ -45,7 +45,9 @@ const PriceInput: React.FC<PriceInputProps> = ({
       {balance ? (
         <ContainerSpan>
           <LeftSpan>
-            <OpacitySpan>Balance:</OpacitySpan>{' '}
+            <OpacitySpan>
+              <Label text={'balance'} />
+            </OpacitySpan>
           </LeftSpan>
           <RightSpan>
             {formatEtherBalance(balance.raw.toString())}{' '}

--- a/app/src/components/PriceInput/PriceInput.tsx
+++ b/app/src/components/PriceInput/PriceInput.tsx
@@ -40,8 +40,11 @@ const PriceInput: React.FC<PriceInputProps> = ({
         startAdornment={!startAdornment ? startAdornment : null}
         onChange={onChange}
         value={`${quantity ? quantity.toString() : ''}`}
-        endAdornment={<Button size="sm" text="Max" onClick={onClick} />}
+        endAdornment={
+          <Button size="sm" variant="secondary" text="Max" onClick={onClick} />
+        }
       />
+      <Spacer size="sm" />
       {balance ? (
         <ContainerSpan>
           <LeftSpan>

--- a/app/src/components/TopBar/TopBar.tsx
+++ b/app/src/components/TopBar/TopBar.tsx
@@ -52,6 +52,15 @@ const TopBar: React.FC = () => {
               Markets
             </StyledNavItem>
           </Link>
+          <Link href="/contracts">
+            <StyledNavItem
+              active={
+                location.pathname.indexOf('/contracts') !== -1 ? true : false
+              }
+            >
+              Contracts
+            </StyledNavItem>
+          </Link>
           <Link href="/faq">
             <StyledNavItem active={location.pathname === '/faq' ? true : false}>
               FAQ

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -106,6 +106,7 @@ export enum QueryParameters {
 
 export enum LocalStorageKeys {
   Version = 'version',
+  Disclaimer = 'disclaimer',
   Deadline = 'deadline',
   Slippage = 'slippage',
   Transactions = 'transactions',

--- a/app/src/hooks/useTokenAllowance.ts
+++ b/app/src/hooks/useTokenAllowance.ts
@@ -30,8 +30,6 @@ const useTokenAllowance = (tokenAddress: string, spender: string) => {
       return () => clearInterval(refreshInterval)
     }
   }, [account, library, setAllowance, tokenAddress])
-  console.log(tokenAddress)
-  console.log(allowance)
   return allowance
 }
 export default useTokenAllowance

--- a/app/src/hooks/user/index.ts
+++ b/app/src/hooks/user/index.ts
@@ -6,7 +6,7 @@ import { Web3Provider } from '@ethersproject/providers'
 
 import { useLocalStorage } from '../utils/useLocalStorage'
 import { injected } from '../../connectors'
-import { LocalStorageKeys, DEFAULT_SLIPPAGE } from '../../constants'
+import { LocalStorageKeys, DEFAULT_SLIPPAGE } from '@/constants/index'
 
 import { TradeSettings } from '@/lib/types'
 import {
@@ -26,6 +26,9 @@ export function useSlippage() {
   return useLocalStorage<string>(LocalStorageKeys.Slippage, DEFAULT_SLIPPAGE)
 }
 
+export function useDisclaimer() {
+  return useLocalStorage<boolean>(LocalStorageKeys.Disclaimer, false)
+}
 export function useTradeSettings(): TradeSettings {
   const [slippage] = useSlippage()
   const { account, chainId } = useWeb3React()

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import Button from '@/components/Button'
 import store from '@/state/index'
 import theme from '../theme'
 import TransactionUpdater from '@/state/transactions/updater'
-
+import { useDisclaimer } from '@/hooks/user/index'
 const GlobalStyle = createGlobalStyle`
   html,
   body {

--- a/app/src/pages/contracts/index.tsx
+++ b/app/src/pages/contracts/index.tsx
@@ -1,0 +1,12 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+
+import Spacer from '@/components/Spacer'
+const Contracts: React.FC = () => {
+  return (
+    <>
+      <Spacer></Spacer>
+    </>
+  )
+}
+export default Contracts

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -9,7 +9,7 @@ import MetaMaskOnboarding from '@metamask/onboarding'
 import BetaBanner from '@/components/BetaBanner'
 import Spacer from '@/components/Spacer'
 
-import { ADDRESS_FOR_MARKET } from '@/constants/index'
+import { ADDRESS_FOR_MARKET, Operation } from '@/constants/index'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { Grid, Col, Row } from 'react-styled-flexboxgrid'
 import { useClearNotif } from '@/state/notifs/hooks'
@@ -41,7 +41,7 @@ const Market = ({ market, data }) => {
   const [callPutActive, setCallPutActive] = useState(true)
   const [expiry, setExpiry] = useState(1609286400)
   const { chainId, active, account } = useActiveWeb3React()
-  const { item } = useItem()
+  const { item, orderType } = useItem()
   const router = useRouter()
   const clear = useClearNotif()
   useEffect(() => {
@@ -126,7 +126,9 @@ const Market = ({ market, data }) => {
 
             <StyledCol sm={12} md={4} lg={4}>
               <StyledSideBar>
-                {item.address ? null : <BalanceCard />}
+                {item.address && orderType !== Operation.NONE ? null : (
+                  <BalanceCard />
+                )}
                 <Spacer />
                 <PositionsCard />
                 <OrderCard orderState={data} />
@@ -150,7 +152,6 @@ const StyledContainer = styled(Col)`
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  overflow: hidden;
   flex-grow: 1;
 `
 const StyledMain = styled.div``

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -129,11 +129,11 @@ const Market = ({ market, data }) => {
                 {item.address && orderType !== Operation.NONE ? null : (
                   <BalanceCard />
                 )}
-                <Spacer />
+                <Spacer size="sm" />
                 <PositionsCard />
                 <OrderCard orderState={data} />
                 <NewMarketCard />
-                <Spacer />
+                <Spacer size="sm" />
                 <TransactionCard />
               </StyledSideBar>
             </StyledCol>

--- a/app/src/pages/markets/[...id].tsx
+++ b/app/src/pages/markets/[...id].tsx
@@ -13,6 +13,7 @@ import { ADDRESS_FOR_MARKET } from '@/constants/index'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { Grid, Col, Row } from 'react-styled-flexboxgrid'
 import { useClearNotif } from '@/state/notifs/hooks'
+import { useItem } from '@/state/order/hooks'
 import Loader from '@/components/Loader'
 import {
   FilterBar,
@@ -40,7 +41,7 @@ const Market = ({ market, data }) => {
   const [callPutActive, setCallPutActive] = useState(true)
   const [expiry, setExpiry] = useState(1609286400)
   const { chainId, active, account } = useActiveWeb3React()
-
+  const { item } = useItem()
   const router = useRouter()
   const clear = useClearNotif()
   useEffect(() => {
@@ -125,8 +126,7 @@ const Market = ({ market, data }) => {
 
             <StyledCol sm={12} md={4} lg={4}>
               <StyledSideBar>
-                <Spacer />
-                <BalanceCard />
+                {item.address ? null : <BalanceCard />}
                 <Spacer />
                 <PositionsCard />
                 <OrderCard orderState={data} />

--- a/app/src/state/notifs/reducer.ts
+++ b/app/src/state/notifs/reducer.ts
@@ -16,7 +16,6 @@ export default createReducer(initialState, (builder) =>
   builder
     .addCase(addNotif, (state, { payload: { id, title, msg, link } }) => {
       state[id] = { title, msg, link }
-      console.log(state)
       return state
     })
     .addCase(clearNotif, (state, { payload: id }) => {
@@ -24,7 +23,6 @@ export default createReducer(initialState, (builder) =>
       return state
     })
     .addCase(resetNotif, (state) => {
-      console.log('reset')
       state = {}
       return state
     })

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -210,7 +210,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               premium,
                               true
                             )
-                            console.log(option)
+                            console.log(reserves[0].toString())
                             calls.push({
                               entity: option,
                               asset: assetName,
@@ -257,7 +257,6 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               premium,
                               false
                             )
-
                             puts.push({
                               entity: option,
                               asset: assetName,
@@ -265,7 +264,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               change: 0,
                               premium: premium,
                               shortPremium: shortPremium,
-                              strike: strikePrice.quantity,
+                              strike: option.strikePrice.quantity,
                               volume: 0,
                               reserves: reserves,
                               token0: token0,

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -210,6 +210,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               premium,
                               true
                             )
+                            console.log(option)
                             calls.push({
                               entity: option,
                               asset: assetName,

--- a/app/src/state/order/hooks.tsx
+++ b/app/src/state/order/hooks.tsx
@@ -42,6 +42,7 @@ export const useItem = (): {
   orderType: Operation
   loading: boolean
   approved: boolean
+  lpApproved: boolean
 } => {
   const state = useSelector<AppState, AppState['order']>((state) => state.order)
   return state
@@ -51,7 +52,8 @@ export const useUpdateItem = (): ((
   item: OptionsAttributes,
   orderType: Operation,
   loading?: boolean,
-  approved?: boolean
+  approved?: boolean,
+  lpApproved?: boolean
 ) => void) => {
   const dispatch = useDispatch<AppDispatch>()
 
@@ -60,9 +62,10 @@ export const useUpdateItem = (): ((
       item: OptionsAttributes,
       orderType: Operation,
       loading?: boolean,
-      approved?: boolean
+      approved?: boolean,
+      lpApproved?: boolean
     ) => {
-      dispatch(updateItem({ item, orderType, loading, approved }))
+      dispatch(updateItem({ item, orderType, loading, approved, lpApproved }))
     },
     [dispatch]
   )

--- a/app/src/state/order/reducer.ts
+++ b/app/src/state/order/reducer.ts
@@ -8,6 +8,7 @@ export interface OrderState {
   orderType?: Operation
   loading?: boolean
   approved?: boolean
+  lpApproved?: boolean
 }
 
 export const initialState: OrderState = {
@@ -15,14 +16,18 @@ export const initialState: OrderState = {
   orderType: Operation.NEUTRAL,
   loading: false,
   approved: false,
+  lpApproved: false,
 }
 
 export default createReducer(initialState, (builder) =>
   builder
     .addCase(
       updateItem,
-      (state, { payload: { item, orderType, loading, approved } }) => {
-        return { ...state, item, orderType, loading, approved }
+      (
+        state,
+        { payload: { item, orderType, loading, approved, lpApproved } }
+      ) => {
+        return { ...state, item, orderType, loading, approved, lpApproved }
       }
     )
     .addCase(removeItem, () => {


### PR DESCRIPTION
Closes #190 
Closes #204 
Closes #207 
Closes #210 

Partially completed #203 

Known issue -> Pairs with no liquidity (SUSHI on rinkeby, for example) are showing liquidity in the total reserve.  This leads to the add liquidity order view thinking the LP market already exists, not letting users set the ratio of the new pair.