### PR TITLE
Fixes #208. Adds a label in the withdraw liquidity card if user is mi…

### DIFF
--- a/app/src/hooks/useTokenBalance.ts
+++ b/app/src/hooks/useTokenBalance.ts
@@ -20,7 +20,7 @@ const useTokenBalance = (tokenAddress: string) => {
       balance = await getBalance(library, tokenAddress, account)
     }
     if (balance) {
-      setBalance(formatEther(balance).toString())
+      setBalance(formatEther(balance))
     }
   }, [account, library, tokenAddress])
 


### PR DESCRIPTION
…ssing a balance.

![image](https://user-images.githubusercontent.com/38409137/99734627-fda73280-2a77-11eb-9888-478b8b76800a.png)

Adds the line "And requires xxx Options".
If a user does not have enough long options to close their position, this line will be rendered. If a user does have enough long option tokens, this won't show.

We should do additional work on warning labels for when users dont have a balance to do a transaction.