### PR TITLE
Partial fix for #205. Adds ui guard caps for mainnet. Needs actual pr…

### DIFF
--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -9,6 +9,7 @@ import LineItem from '@/components/LineItem'
 import PriceInput from '@/components/PriceInput'
 import Spacer from '@/components/Spacer'
 import Tooltip from '@/components/Tooltip'
+import WarningLabel from '@/components/WarningLabel'
 import { Operation, UNISWAP_CONNECTOR } from '@/constants/index'
 
 import { BigNumber } from 'ethers'
@@ -19,6 +20,7 @@ import useApprove from '@/hooks/useApprove'
 import useTokenAllowance from '@/hooks/useTokenAllowance'
 import useTokenBalance from '@/hooks/useTokenBalance'
 import useTokenTotalSupply from '@/hooks/useTokenTotalSupply'
+import useGuardCap from '@/hooks/useGuardCap'
 
 import { Trade } from '@/lib/entities/trade'
 import { UNISWAP_ROUTER02_V2 } from '@/lib/constants'
@@ -38,6 +40,8 @@ import {
 import { useWeb3React } from '@web3-react/core'
 import { Token, TokenAmount } from '@uniswap/sdk'
 import { useAddNotif } from '@/state/notifs/hooks'
+
+import formatEtherBalance from '@/utils/formatEtherBalance'
 
 const AddLiquidity: React.FC = () => {
   // executes transactions
@@ -61,6 +65,8 @@ const AddLiquidity: React.FC = () => {
   const { library, chainId } = useWeb3React()
   // approval
   const addNotif = useAddNotif()
+  // guard cap
+  const guardCap = useGuardCap(orderType)
   // pair and option entities
   const entity = item.entity
   const underlyingToken: Token = new Token(
@@ -293,6 +299,19 @@ const AddLiquidity: React.FC = () => {
     return formatEther(quote.toString())
   }, [lpPair, lp, lpTotalSupply, inputs])
 
+  const calculateInputValue = useCallback(() => {
+    const price = parseEther('1') // FIX WITH ACTUAL UNDERLYING PRICE
+    const input =
+      inputs.primary !== '' ? parseEther(inputs.primary) : parseEther('0')
+    const totalValue = input.mul(price).div(parseEther('1'))
+    return totalValue
+  }, [inputs])
+
+  const isAboveGuardCap = useCallback(() => {
+    const inputValue = calculateInputValue()
+    return inputValue.gt(guardCap) && chainId === 1
+  }, [calculateInputValue, guardCap])
+
   useEffect(() => {
     if (tokenAllowance) {
       const approve: boolean = parseEther(tokenAllowance).gt(
@@ -450,7 +469,18 @@ const AddLiquidity: React.FC = () => {
       ) : (
         <> </>
       )}
-
+      {isAboveGuardCap() ? (
+        <>
+          <Spacer />
+          <WarningLabel>
+            This amount of underlying tokens is above our guardrail cap of $
+            {formatEtherBalance(guardCap)}
+          </WarningLabel>
+          <Spacer />
+        </>
+      ) : (
+        <></>
+      )}
       <Box row justifyContent="flex-start">
         {approved ? (
           <> </>
@@ -468,12 +498,12 @@ const AddLiquidity: React.FC = () => {
         )}
 
         <Button
-          disabled={!approved || !inputs || submitting}
+          disabled={!approved || !inputs || submitting || isAboveGuardCap()}
           full
           size="sm"
           onClick={handleSubmitClick}
           isLoading={submitting}
-          text="Review Transaction"
+          text={isAboveGuardCap() ? 'Above Cap' : 'Review Transaction'}
         />
       </Box>
     </>

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -9,7 +9,10 @@ import LineItem from '@/components/LineItem'
 import PriceInput from '@/components/PriceInput'
 import Spacer from '@/components/Spacer'
 import Tooltip from '@/components/Tooltip'
+import WarningLabel from '@/components/WarningLabel'
 import { Operation, UNISWAP_CONNECTOR } from '@/constants/index'
+
+import useGuardCap from '@/hooks/useGuardCap'
 
 import { BigNumber } from 'ethers'
 import { parseEther, formatEther } from 'ethers/lib/utils'
@@ -35,6 +38,8 @@ import { useAddNotif } from '@/state/notifs/hooks'
 import { useWeb3React } from '@web3-react/core'
 import { Token, TokenAmount } from '@uniswap/sdk'
 
+import formatEtherBalance from '@/utils/formatEtherBalance'
+
 const Swap: React.FC = () => {
   // executes transactions
   const submitOrder = useHandleSubmitOrder()
@@ -53,6 +58,8 @@ const Swap: React.FC = () => {
   // web3
   const { library, chainId } = useWeb3React()
   const addNotif = useAddNotif()
+  // guard cap
+  const guardCap = useGuardCap(orderType)
 
   // pair and option entities
   const entity = item.entity
@@ -152,6 +159,19 @@ const Swap: React.FC = () => {
     return debit
   }, [item, inputs])
 
+  const calculateInputValue = useCallback(() => {
+    const price = parseEther('1') // FIX WITH ACTUAL UNDERLYING PRICE
+    const input =
+      inputs.primary !== '' ? parseEther(inputs.primary) : parseEther('0')
+    const totalValue = input.mul(price).div(parseEther('1'))
+    return totalValue
+  }, [inputs])
+
+  const isAboveGuardCap = useCallback(() => {
+    const inputValue = calculateInputValue()
+    return inputValue.gt(guardCap) && chainId === 1
+  }, [calculateInputValue, guardCap])
+
   //APPROVALS
   useEffect(() => {
     if (parseInt(tokenAllowance) > 0) {
@@ -250,6 +270,19 @@ const Swap: React.FC = () => {
         <> </>
       )}
 
+      {isAboveGuardCap() ? (
+        <>
+          <Spacer />
+          <WarningLabel>
+            This amount of underlying tokens is above our guardrail cap of $
+            {formatEtherBalance(guardCap)}
+          </WarningLabel>
+          <Spacer />
+        </>
+      ) : (
+        <></>
+      )}
+
       <Box row justifyContent="flex-start">
         {approved ? (
           <> </>
@@ -267,7 +300,7 @@ const Swap: React.FC = () => {
           </>
         )}
         <Button
-          disabled={!approved || !inputs || loading}
+          disabled={!approved || !inputs || loading || isAboveGuardCap()}
           full
           size="sm"
           onClick={handleSubmitClick}

--- a/app/src/components/WarningLabel/WarningLabel.tsx
+++ b/app/src/components/WarningLabel/WarningLabel.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const WarningLabel: React.FC = ({ children }) => (
+  <StyledWarningLabel>{children}</StyledWarningLabel>
+)
+
+const StyledWarningLabel = styled.div`
+  color: ${(props) => props.theme.color.red[500]};
+  display: flex;
+  font-size: 14px;
+  justify-content: center;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  opacity: 0.66;
+  width: 100%;
+`
+
+export default WarningLabel

--- a/app/src/components/WarningLabel/index.ts
+++ b/app/src/components/WarningLabel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WarningLabel'

--- a/app/src/hooks/useGuardCap.ts
+++ b/app/src/hooks/useGuardCap.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect, useState } from 'react'
+import ethers, { BigNumber } from 'ethers'
+import { Operation } from '../constants'
+
+const useGuardCap = (orderType: Operation): BigNumber => {
+  let cap: string
+  switch (orderType) {
+    case Operation.ADD_LIQUIDITY:
+      cap = '15000'
+      break
+    default:
+      cap = '10000'
+      break
+  }
+  return ethers.utils.parseEther(cap)
+}
+export default useGuardCap


### PR DESCRIPTION
…ice info.

NOT COMPLETE

Changelog
- Adds WarningLabel to display red text if the guard cap is reached
- Adds useGuardCap hook which returns guard cap values based on the Operation enum order types
- Adds isAboveGuardCap() functions to AddLiquidity and Swap components. Disabled Submit button if true.
- Checks guards only on mainnet.

To do
- The function calculateInputValue() calculates the current value desired to be submitted. This value is not using the ACTUAL price data of the underlying token. We need to add the price data to get the real inputValue, which can then be compared to the guard cap value.