### PR TITLE
Adds closePremium to option attributes and trade.ts file.

### DIFF
--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -213,6 +213,12 @@ const Swap: React.FC = () => {
           data={formatEther(item.shortPremium)}
           units={entity.isPut ? 'DAI' : item.asset}
         />
+      ) : orderType === Operation.CLOSE_LONG ? (
+        <LineItem
+          label="Option Premium"
+          data={formatEther(item.closePremium)}
+          units={entity.isPut ? 'DAI' : item.asset}
+        />
       ) : (
         <LineItem
           label="Option Premium"

--- a/app/src/lib/entities/trade.ts
+++ b/app/src/lib/entities/trade.ts
@@ -274,16 +274,54 @@ export class Trade {
     return premium
   }
 
-  public static getShortPremium = (
-    quantityOptions: BigNumberish,
+  public static getClosePremium = (
+    quantityShort: BigNumberish,
+    base: BigNumberish,
+    quote: BigNumberish,
+    path: string[], // redeem -> underlying
     reserves: BigNumberish[]
   ): BigNumberish => {
     if (BigNumber.from(reserves[0]).isZero()) {
       return 0
     }
-    const amountOut = Trade.getQuote(quantityOptions, reserves[0], reserves[1])
+    const underlyingsMinted = ethers.BigNumber.from(quantityShort)
+      .mul(base)
+      .div(quote)
+    // CLOSE PREMIUM MATH
+    const amountsIn = Trade.getAmountsInPure(
+      quote,
+      path,
+      reserves[0],
+      reserves[1]
+    )
+    const underlyingsRequired = amountsIn[0]
+    const underlyingPayout = BigNumber.from(base).gt(underlyingsRequired)
+      ? BigNumber.from(base).sub(underlyingsRequired)
+      : parseEther('0')
+    return underlyingPayout
+  }
+
+  public static getShortPremium = (
+    quantityShort: BigNumberish,
+    reserves: BigNumberish[]
+  ): BigNumberish => {
+    if (BigNumber.from(reserves[0]).isZero()) {
+      return 0
+    }
+    const amountOut = Trade.getQuote(quantityShort, reserves[0], reserves[1])
     const shortPremium = BigNumber.from(amountOut)
     return shortPremium
+  }
+
+  public static getCloseSpotPremium = (
+    base: BigNumberish,
+    quote: BigNumberish,
+    path: string[], // redeem -> underlying
+    reserves: BigNumberish[]
+  ): BigNumberish => {
+    const quantity = parseEther('1')
+    const premium = Trade.getClosePremium(quantity, base, quote, path, reserves)
+    return premium
   }
 
   public static getSpotPremium = (

--- a/app/src/state/options/actions.ts
+++ b/app/src/state/options/actions.ts
@@ -16,6 +16,7 @@ export type OptionsAttributes = {
   breakEven: BigNumberish
   change: BigNumberish
   premium: BigNumberish
+  closePremium: BigNumberish
   shortPremium: BigNumberish
   strike: BigNumberish
   volume: BigNumberish

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -187,6 +187,18 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                           path,
                           [shortReserve, underlyingReserve]
                         )
+                        let closePremium: BigNumberish = Trade.getCloseSpotPremium(
+                          Base.quantity,
+                          Quote.quantity,
+                          [option.assetAddresses[0], option.assetAddresses[2]],
+                          [underlyingReserve, shortReserve]
+                        )
+                        if (
+                          option.address ===
+                          '0x5687FB863696fa2ACCCb6F7ea9708551D09505d4'
+                        ) {
+                          console.log(closePremium.toString())
+                        }
                         const shortPremium: BigNumberish = Trade.getSpotShortPremium(
                           [shortReserve, underlyingReserve]
                         )
@@ -220,6 +232,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               breakEven: breakEven,
                               change: 0,
                               premium: premium,
+                              closePremium: closePremium,
                               shortPremium: shortPremium,
                               strike: option.strikePrice.quantity,
                               volume: 0,
@@ -268,6 +281,7 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                               breakEven: breakEven,
                               change: 0,
                               premium: premium,
+                              closePremium: closePremium,
                               shortPremium: shortPremium,
                               strike: strikePrice.quantity,
                               volume: 0,

--- a/app/src/state/options/hooks.tsx
+++ b/app/src/state/options/hooks.tsx
@@ -193,12 +193,6 @@ export const useUpdateOptions = (): ((assetName: string) => void) => {
                           [option.assetAddresses[0], option.assetAddresses[2]],
                           [underlyingReserve, shortReserve]
                         )
-                        if (
-                          option.address ===
-                          '0x5687FB863696fa2ACCCb6F7ea9708551D09505d4'
-                        ) {
-                          console.log(closePremium.toString())
-                        }
                         const shortPremium: BigNumberish = Trade.getSpotShortPremium(
                           [shortReserve, underlyingReserve]
                         )

--- a/app/src/state/options/reducer.ts
+++ b/app/src/state/options/reducer.ts
@@ -11,6 +11,7 @@ export type OptionsAttributes = {
   breakEven: BigNumberish
   change: BigNumberish
   premium: BigNumberish
+  closePremium: BigNumberish
   shortPremium: BigNumberish
   strike: BigNumberish
   volume: BigNumberish
@@ -36,6 +37,7 @@ export const EmptyAttributes = {
   breakEven: 0,
   change: 0,
   premium: 0,
+  closePremium: 0,
   shortPremium: 0,
   strike: 0,
   volume: 0,


### PR DESCRIPTION
Changelog
- Adds `getCloseSpotPremium` to `trade.ts`.
- Adds `closePremium` to `OptionAttributes` in initial option fetching.
- Displays the close premium instead of the open premium on the close long order card.

Interesting note:
- Open premium = ask?
- Close premium = bid?