### PR TITLE
feat(explicit-info): Removes Quantity, Asset. Adds Token, TokenAmount.

### DIFF
--- a/app/src/components/Market/BalanceCard/index.tsx
+++ b/app/src/components/Market/BalanceCard/index.tsx
@@ -32,7 +32,7 @@ const BalanceCard: React.FC = () => {
     let tx: any
     mintTestTokens(
       account,
-      calls[0].entity.assetAddresses[0],
+      calls[0].entity.tokenAddresses[0],
       await library.getSigner()
     )
       .then((tx) => {
@@ -84,8 +84,8 @@ const BalanceCard: React.FC = () => {
             <LineItem label={`DAI Balance`} data={daiBal} />
             <Spacer size="sm" />
             <LineItem
-              label={`${balance.asset.symbol} Balance`}
-              data={formatEther(balance.quantity)}
+              label={`${balance.token.symbol} Balance`}
+              data={formatEther(balance.raw.toString())}
             />
             {chainId === 4 ? (
               <>

--- a/app/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -12,7 +12,11 @@ import formatAddress from '@/utils/formatAddress'
 import formatBalance from '@/utils/formatBalance'
 import formatEtherBalance from '@/utils/formatEtherBalance'
 import { useWeb3React } from '@web3-react/core'
-import { ETHERSCAN_MAINNET, ETHERSCAN_RINKEBY } from '@/constants/index'
+import {
+  ADDRESS_FOR_MARKET,
+  ETHERSCAN_MAINNET,
+  ETHERSCAN_RINKEBY,
+} from '@/constants/index'
 import { Operation } from '@/constants/index'
 
 import { BigNumber } from 'ethers'
@@ -69,9 +73,9 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
       () => {
         if (library) {
           if (asset === 'eth') {
-            updateOptions('WETH')
+            updateOptions('WETH', ADDRESS_FOR_MARKET[asset])
           } else {
-            updateOptions(asset.toUpperCase())
+            updateOptions(asset.toUpperCase(), ADDRESS_FOR_MARKET[asset])
           }
         }
       },
@@ -79,9 +83,9 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
     )
     if (library) {
       if (asset === 'eth') {
-        updateOptions('WETH')
+        updateOptions('WETH', ADDRESS_FOR_MARKET[asset])
       } else {
-        updateOptions(asset.toUpperCase())
+        updateOptions(asset.toUpperCase(), ADDRESS_FOR_MARKET[asset])
       }
     }
     return () => {
@@ -103,8 +107,12 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
         .mul(spotPriceWei)
         .div(parseEther('1'))
       const breakeven = option.entity.isCall
-        ? BigNumber.from(option.entity.quote.quantity).add(spotPriceDai)
-        : BigNumber.from(option.entity.base.quantity).sub(option.premium)
+        ? BigNumber.from(option.entity.quoteValue.raw.toString()).add(
+            spotPriceDai
+          )
+        : BigNumber.from(option.entity.baseValue.raw.toString()).sub(
+            option.premium
+          )
       return breakeven.toString()
     },
     [key, data]
@@ -187,7 +195,7 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
       const tableDepth: string = option.depth.toString()
 
       const reserve0Units =
-        option.token0 === option.entity.assetAddresses[0]
+        option.token0 === option.entity.underlying.address
           ? asset.toUpperCase()
           : 'SHORT'
 

--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -78,47 +78,31 @@ const AddLiquidity: React.FC = () => {
   const guardCap = useGuardCap(item.asset, orderType)
   // pair and option entities
   const entity = item.entity
-  const isPut = item.entity.isPut
-  const underlyingToken: Token = new Token(
-    entity.chainId,
-    entity.assetAddresses[0],
-    18,
-    isPut ? 'DAI' : item.asset.toUpperCase()
-  )
-  const shortToken = new Token(
-    entity.chainId,
-    entity.assetAddresses[2],
-    18,
-    'SHORT'
-  )
-  const lpPair = useReserves(underlyingToken, shortToken).data
+  const lpPair = useReserves(entity.underlying, entity.redeem).data
   // has liquidity?
   useEffect(() => {
     if (lpPair) {
-      setHasL(lpPair.reserveOf(shortToken).numerator[2])
+      setHasL(lpPair.reserveOf(entity.redeem).numerator[2])
     }
   }, [setHasL, lpPair])
 
   const lpToken = lpPair ? lpPair.liquidityToken.address : ''
   const token0 = lpPair ? lpPair.token0.symbol : ''
   const token1 = lpPair ? lpPair.token1.symbol : ''
-  const underlyingTokenBalance = useTokenBalance(underlyingToken.address)
-  const shortTokenBalance = useTokenBalance(entity.assetAddresses[2])
+  const underlyingTokenBalance = useTokenBalance(entity.underlying.address)
+  const shortTokenBalance = useTokenBalance(entity.redeem.address)
   const lp = useTokenBalance(lpToken)
   const lpTotalSupply = useTokenTotalSupply(lpToken)
   const spender = UNISWAP_CONNECTOR[chainId]
-  const tokenAllowance = useTokenAllowance(
-    item.entity.assetAddresses[0],
-    spender
-  )
-  const { onApprove } = useApprove(underlyingToken.address, spender)
+  const tokenAllowance = useTokenAllowance(entity.underlying.address, spender)
+  const { onApprove } = useApprove(entity.underlying.address, spender)
 
   const underlyingAmount: TokenAmount = new TokenAmount(
-    underlyingToken,
+    entity.underlying,
     parseEther(underlyingTokenBalance).toString()
   )
   const shortAmount: TokenAmount = new TokenAmount(
-    shortToken,
+    entity.redeem,
     parseEther(shortTokenBalance).toString()
   )
 
@@ -179,7 +163,7 @@ const AddLiquidity: React.FC = () => {
         ? Number(parseInt(supply.div(parsedUnderlyingAmount).toString()))
         : 0
 
-    return 0
+    return poolShare
   }, [lpPair, lp, lpTotalSupply, parsedUnderlyingAmount])
 
   const calculateOutput = useCallback(() => {
@@ -188,14 +172,12 @@ const AddLiquidity: React.FC = () => {
       return sum
     }
     const reservesA = lpPair.reserveOf(
-      new Token(chainId, item.entity.assetAddresses[2], 18)
+      new Token(chainId, entity.redeem.address, 18)
     )
     const reservesB = lpPair.reserveOf(
-      new Token(chainId, item.entity.assetAddresses[0], 18)
+      new Token(chainId, entity.underlying.address, 18)
     )
-    const inputShort = calculateInput() // pair has short tokens, so need to convert our desired options to short options
-      .mul(item.entity.optionParameters.quote.quantity)
-      .div(item.entity.optionParameters.base.quantity)
+    const inputShort = entity.proportionalShort(calculateInput()) // pair has short tokens, so need to convert our desired options to short options
     const quote = Trade.getQuote(
       inputShort,
       reservesA.raw.toString(),
@@ -208,28 +190,18 @@ const AddLiquidity: React.FC = () => {
   const calculateInput = useCallback(() => {
     if (typeof lpPair === 'undefined' || lpPair === null) {
       const sum = parsedUnderlyingAmount.add(parsedOptionAmount)
-      console.log(sum)
       return sum
     }
-    const reservesA = lpPair.reserveOf(
-      new Token(chainId, item.entity.assetAddresses[2], 18)
-    )
-    const reservesB = lpPair.reserveOf(
-      new Token(chainId, item.entity.assetAddresses[0], 18)
-    )
+    const reservesA = lpPair.reserveOf(entity.redeem)
+    const reservesB = lpPair.reserveOf(entity.underlying)
 
-    const ratio = parseEther('1')
-      .mul(item.entity.optionParameters.quote.quantity)
-      .div(item.entity.optionParameters.base.quantity)
+    const ratio = entity.proportionalShort(parseEther('1'))
 
-    console.log(ratio.toString())
     const denominator = ratio
       .mul(reservesB.raw.toString())
       .div(reservesA.raw.toString())
       .add(parseEther('1'))
-    console.log(denominator.toString())
     const optionsInput = parsedOptionAmount.div(denominator)
-    console.log(optionsInput)
     return optionsInput
   }, [lpPair, lp, lpTotalSupply, parsedOptionAmount])
 
@@ -245,11 +217,11 @@ const AddLiquidity: React.FC = () => {
         totalUnderlyingPerLp: '0',
       }
     const SHORT: Token =
-      lpPair.token0.address === item.entity.assetAddresses[2]
+      lpPair.token0.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
     const UNDERLYING: Token =
-      lpPair.token1.address === item.entity.assetAddresses[2]
+      lpPair.token1.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
 
@@ -283,8 +255,8 @@ const AddLiquidity: React.FC = () => {
       : '0'
     const totalUnderlyingPerLp = formatEther(
       BigNumber.from(shortValue.raw.toString())
-        .mul(item.entity.optionParameters.base.quantity)
-        .div(item.entity.optionParameters.quote.quantity)
+        .mul(entity.baseValue.raw.toString())
+        .div(entity.quoteValue.raw.toString())
         .add(underlyingValue.raw.toString())
     )
 
@@ -298,31 +270,26 @@ const AddLiquidity: React.FC = () => {
       !hasLiquidity ||
       parsedOptionAmount !== undefined
     ) {
-      const inputShort = parsedOptionAmount // pair has short tokens, so need to convert our desired options to short options
-        .mul(item.entity.optionParameters.quote.quantity)
-        .div(item.entity.optionParameters.base.quantity)
-      const path = [
-        item.entity.assetAddresses[2],
-        item.entity.assetAddresses[0],
-      ]
+      const inputShort = entity.proportionalShort(parsedOptionAmount) // pair has short tokens, so need to convert our desired options to short options))
+      const path = [entity.redeem.address, entity.underlying.address]
       const quote = Trade.getSpotPremium(
-        item.entity.optionParameters.base.quantity,
-        item.entity.optionParameters.quote.quantity,
+        entity.baseValue.raw.toString(),
+        entity.quoteValue.raw.toString(),
         path,
         [inputShort, parsedUnderlyingAmount]
       )
       return formatEther(quote.toString())
     }
     const reservesA = lpPair.reserveOf(
-      new Token(chainId, item.entity.assetAddresses[2], 18)
+      new Token(chainId, entity.redeem.address, 18)
     )
     const reservesB = lpPair.reserveOf(
-      new Token(chainId, item.entity.assetAddresses[0], 18)
+      new Token(chainId, entity.underlying.address, 18)
     )
-    const path = [item.entity.assetAddresses[2], item.entity.assetAddresses[0]]
+    const path = [entity.redeem.address, entity.underlying.address]
     const quote = Trade.getSpotPremium(
-      item.entity.optionParameters.base.quantity,
-      item.entity.optionParameters.quote.quantity,
+      entity.baseValue.raw.toString(),
+      entity.quoteValue.raw.toString(),
       path,
       [reservesA.raw.toString(), reservesB.raw.toString()]
     )
@@ -340,12 +307,12 @@ const AddLiquidity: React.FC = () => {
       .catch((error) => {
         addNotif(
           0,
-          `Approving ${underlyingToken.symbol.toUpperCase()}`,
+          `Approving ${entity.underlying.symbol.toUpperCase()}`,
           error.message,
           ''
         )
       })
-  }, [underlyingToken, tokenAllowance, onApprove])
+  }, [entity.underlying, tokenAllowance, onApprove])
 
   const title = {
     text: 'Add Liquidity',
@@ -401,7 +368,7 @@ const AddLiquidity: React.FC = () => {
               onClick={handleSetMax}
               balance={
                 new TokenAmount(
-                  underlyingToken,
+                  entity.underlying,
                   parseEther(underlyingTokenBalance).toString()
                 )
               }
@@ -468,7 +435,7 @@ const AddLiquidity: React.FC = () => {
           <LineItem
             label="Implied Option Price"
             data={`${calculateImpliedPrice()}`}
-            units={`${underlyingToken.symbol.toUpperCase()}`}
+            units={`${entity.underlying.symbol.toUpperCase()}`}
           />
           <Spacer size="sm" />{' '}
         </>
@@ -507,7 +474,7 @@ const AddLiquidity: React.FC = () => {
           />
           <Spacer size="sm" />
           <LineItem
-            label={`Total ${underlyingToken.symbol.toUpperCase()} per LP Token`}
+            label={`Total ${entity.underlying.symbol.toUpperCase()} per LP Token`}
             data={`${calculateLiquidityValuePerShare().totalUnderlyingPerLp}`}
           />
           <Spacer size="sm" />
@@ -560,7 +527,7 @@ const AddLiquidity: React.FC = () => {
                   full
                   size="sm"
                   onClick={handleApproval}
-                  text={`Approve ${underlyingToken.symbol.toUpperCase()}`}
+                  text={`Approve ${entity.underlying.symbol.toUpperCase()}`}
                 />
               </>
             )}

--- a/app/src/components/Market/OrderCard/components/Manage/Manage.tsx
+++ b/app/src/components/Market/OrderCard/components/Manage/Manage.tsx
@@ -60,12 +60,7 @@ const Manage: React.FC = () => {
 
   // pair and option entities
   const entity = item.entity
-  const underlyingToken: Token = new Token(
-    entity.chainId,
-    entity.assetAddresses[0],
-    18,
-    entity.isPut ? 'DAI' : item.asset.toUpperCase()
-  )
+  const underlyingToken: Token = entity.underlying
 
   let title = { text: '', tip: '' }
   let tokenAddress: string
@@ -93,7 +88,7 @@ const Manage: React.FC = () => {
         text: 'Redeem Strike Tokens',
         tip: `Burn short option tokens to release strike tokens, if options were exercised.`,
       }
-      tokenAddress = entity.assetAddresses[2]
+      tokenAddress = entity.redeem.address
       balance = new Token(entity.chainId, tokenAddress, 18, 'REDEEM')
       break
     case Operation.CLOSE:
@@ -101,7 +96,7 @@ const Manage: React.FC = () => {
         text: 'Close Options',
         tip: `Burn long and short option tokens to receive underlying tokens.`,
       }
-      tokenAddress = entity.address // entity.assetAddresses[2] FIX DOUBLE APPROVAL
+      tokenAddress = entity.address // entity.redeem.address FIX DOUBLE APPROVAL
       balance = new Token(entity.chainId, tokenAddress, 18, 'OPTION')
       break
     default:
@@ -116,7 +111,7 @@ const Manage: React.FC = () => {
   const underlyingTokenBalance = useTokenBalance(underlyingToken.address)
   const { onApprove } = useApprove(tokenAddress, spender)
 
-  const strikeBalance = useTokenBalance(entity.assetAddresses[2])
+  const strikeBalance = useTokenBalance(entity.redeem.address)
 
   const handleInputChange = useCallback(
     (value: string) => {
@@ -160,8 +155,8 @@ const Manage: React.FC = () => {
     let underlying = '0'
     let strike = '0'
     const size = parsedAmount
-    const base = item.entity.base.quantity.toString()
-    const quote = item.entity.quote.quantity.toString()
+    const base = item.entity.baseValue.raw.toString()
+    const quote = item.entity.quoteValue.raw.toString()
     switch (orderType) {
       case Operation.MINT:
         long = size.div(BigNumber.from('1000000000000000000')).toString()

--- a/app/src/components/Market/OrderCard/components/ManageOptions/ManageOptions.tsx
+++ b/app/src/components/Market/OrderCard/components/ManageOptions/ManageOptions.tsx
@@ -22,16 +22,8 @@ import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
   const { item } = useItem()
   const updateItem = useUpdateItem()
-  const underlyingToken: Token = new Token(
-    item.entity.chainId,
-    item.entity.assetAddresses[0],
-    18,
-    item.entity.isPut ? 'DAI' : item.asset.toUpperCase()
-  )
-  const lpPair = useReserves(
-    underlyingToken,
-    new Token(item.entity.chainId, item.entity.assetAddresses[2], 18, 'SHORT')
-  ).data
+  const underlyingToken: Token = item.entity.underlying
+  const lpPair = useReserves(underlyingToken, item.entity.redeem).data
   const change = (t: Operation) => {
     if (t === Operation.REMOVE_LIQUIDITY_CLOSE) {
       console.log(lpPair)
@@ -41,7 +33,7 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
     }
   }
   const reserve0Units =
-    item.token0 === item.entity.assetAddresses[0]
+    item.token0 === item.entity.underlying.address
       ? item.asset.toUpperCase()
       : 'SHORT'
   return (

--- a/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
+++ b/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
@@ -24,14 +24,11 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
   const updateItem = useUpdateItem()
   const underlyingToken: Token = new Token(
     item.entity.chainId,
-    item.entity.assetAddresses[0],
+    item.entity.underlying.address,
     18,
     item.entity.isPut ? 'DAI' : item.asset.toUpperCase()
   )
-  const lpPair = useReserves(
-    underlyingToken,
-    new Token(item.entity.chainId, item.entity.assetAddresses[2], 18, 'SHORT')
-  ).data
+  const lpPair = useReserves(underlyingToken, item.entity.redeem).data
   const change = (t: Operation) => {
     if (t === Operation.REMOVE_LIQUIDITY_CLOSE) {
       console.log(lpPair)
@@ -41,7 +38,7 @@ const LPOptions: React.FC<{ balance?: any }> = ({ balance }) => {
     }
   }
   const reserve0Units =
-    item.token0 === item.entity.assetAddresses[0]
+    item.token0 === item.entity.underlying.address
       ? item.asset.toUpperCase()
       : 'SHORT'
   return (

--- a/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -69,17 +69,7 @@ const RemoveLiquidity: React.FC = () => {
   // pair and option entities
   const addNotif = useAddNotif()
   const entity = item.entity
-  const isPut = item.entity.isPut
-  const underlyingToken: Token = new Token(
-    entity.chainId,
-    entity.assetAddresses[0],
-    18,
-    isPut ? 'DAI' : item.asset.toUpperCase()
-  )
-  const lpPair = useReserves(
-    underlyingToken,
-    new Token(entity.chainId, entity.assetAddresses[2], 18, 'SHORT')
-  ).data
+  const lpPair = useReserves(entity.underlying, entity.redeem).data
 
   const lpToken = lpPair ? lpPair.liquidityToken.address : ''
   const token0 = lpPair ? lpPair.token0.symbol : ''
@@ -88,7 +78,7 @@ const RemoveLiquidity: React.FC = () => {
   const lpTotalSupply = useTokenTotalSupply(lpToken)
   const spender = UNISWAP_CONNECTOR[chainId]
 
-  const underlyingTokenBalance = useTokenBalance(underlyingToken.address)
+  const underlyingTokenBalance = useTokenBalance(entity.underlying.address)
 
   const optionBalance = useTokenBalance(item.address)
 
@@ -191,11 +181,11 @@ const RemoveLiquidity: React.FC = () => {
       }
     }
     const SHORT: Token =
-      lpPair.token0.address === item.entity.assetAddresses[2]
+      lpPair.token0.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
     const UNDERLYING: Token =
-      lpPair.token1.address === item.entity.assetAddresses[2]
+      lpPair.token1.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
 
@@ -230,8 +220,8 @@ const RemoveLiquidity: React.FC = () => {
 
     const totalUnderlyingPerLp = formatEther(
       BigNumber.from(shortValue.raw.toString())
-        .mul(item.entity.optionParameters.base.quantity)
-        .div(item.entity.optionParameters.quote.quantity)
+        .mul(entity.baseValue.raw.toString())
+        .div(entity.quoteValue.raw.toString())
         .add(underlyingValue.raw.toString())
     )
 
@@ -249,14 +239,14 @@ const RemoveLiquidity: React.FC = () => {
     const liquidity = parseEther(lp).mul(ratio).div(1000)
     if (liquidity.isZero()) return '0'
     if (ratio === 0) return '0'
-    const base = item.entity.optionParameters.base.quantity
-    const quote = item.entity.optionParameters.quote.quantity
+    const base = entity.baseValue.raw.toString()
+    const quote = entity.quoteValue.raw.toString()
     const SHORT: Token =
-      lpPair.token0.address === item.entity.assetAddresses[2]
+      lpPair.token0.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
     const UNDERLYING: Token =
-      lpPair.token1.address === item.entity.assetAddresses[2]
+      lpPair.token1.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
 
@@ -298,10 +288,10 @@ const RemoveLiquidity: React.FC = () => {
     const liquidity = parseEther(lp).mul(ratio).div(1000)
     if (liquidity.isZero()) return '0'
     if (ratio === 0) return '0'
-    const base = item.entity.optionParameters.base.quantity
-    const quote = item.entity.optionParameters.quote.quantity
+    const base = entity.baseValue.raw.toString()
+    const quote = entity.quoteValue.raw.toString()
     const SHORT: Token =
-      lpPair.token0.address === item.entity.assetAddresses[2]
+      lpPair.token0.address === entity.redeem.address
         ? lpPair.token0
         : lpPair.token1
     const shortValue = lpPair.getLiquidityValue(
@@ -434,7 +424,7 @@ const RemoveLiquidity: React.FC = () => {
       <LineItem
         label="You will receive"
         data={numeral(calculateUnderlyingOutput()).format('0.00')}
-        units={`${underlyingToken.symbol.toUpperCase()}`}
+        units={`${entity.underlying.symbol.toUpperCase()}`}
       />
       <Spacer size="sm" />
       <IconButton
@@ -459,7 +449,7 @@ const RemoveLiquidity: React.FC = () => {
           />
           <Spacer size="sm" />
           <LineItem
-            label={`Total ${underlyingToken.symbol.toUpperCase()} per LP Token`}
+            label={`Total ${entity.underlying.symbol.toUpperCase()} per LP Token`}
             data={`${calculateLiquidityValuePerShare().totalUnderlyingPerLp}`}
           />
           <Spacer size="sm" />

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -49,8 +49,6 @@ const Swap: React.FC = () => {
   const submitOrder = useHandleSubmitOrder()
   const updateItem = useUpdateItem()
   const removeItem = useRemoveItem()
-  // toggle for advanced info
-  const [advanced, setAdvanced] = useState(false)
   // approval state
   const { item, orderType, loading, approved } = useItem()
   // cost state
@@ -83,24 +81,11 @@ const Swap: React.FC = () => {
   const price = usePrice()
   // pair and option entities
   const entity = item.entity
-  const isPut = item.entity.isPut
-  const underlyingToken: Token = new Token(
-    entity.chainId,
-    entity.assetAddresses[0],
-    18,
-    isPut ? 'DAI' : item.asset.toUpperCase()
-  )
-  const shortToken = new Token(
-    entity.chainId,
-    entity.assetAddresses[2],
-    18,
-    'SHORT'
-  )
-  const lpPair = useReserves(underlyingToken, shortToken).data
+  const lpPair = useReserves(entity.underlying, entity.redeem).data
   // has liquidity?
   useEffect(() => {
     if (lpPair) {
-      setHasL(lpPair.reserveOf(shortToken).numerator[2])
+      setHasL(lpPair.reserveOf(entity.redeem).numerator[2])
     }
   }, [setHasL, lpPair])
 
@@ -113,16 +98,16 @@ const Swap: React.FC = () => {
         text: 'Buy Long Tokens',
         tip: 'Purchase and hold option tokens.',
       }
-      tokenAddress = underlyingToken.address
-      balance = underlyingToken
+      tokenAddress = entity.underlying.address
+      balance = entity.underlying
       break
     case Operation.SHORT:
       title = {
         text: 'Buy Short Tokens',
         tip: 'Purchase tokenized, written covered options.',
       }
-      tokenAddress = underlyingToken.address
-      balance = underlyingToken
+      tokenAddress = entity.underlying.address
+      balance = entity.underlying
       break
     case Operation.WRITE:
       title = {
@@ -130,8 +115,8 @@ const Swap: React.FC = () => {
         tip:
           'Underwrite long option tokens with an underlying token deposit, and sell them for premiums denominated in underlying tokens.',
       }
-      tokenAddress = item.entity.address //underlyingToken.address FIX: double approval
-      balance = underlyingToken
+      tokenAddress = entity.address //entity.underlying.address FIX: double approval
+      balance = entity.underlying
       break
     case Operation.CLOSE_LONG:
       title = {
@@ -146,7 +131,7 @@ const Swap: React.FC = () => {
         text: 'Close Short Position',
         tip: `Sell short option tokens for ${item.asset.toUpperCase()}.`,
       }
-      tokenAddress = entity.assetAddresses[2]
+      tokenAddress = entity.redeem.address
       balance = new Token(entity.chainId, tokenAddress, 18, 'SHORT')
       break
     default:
@@ -161,7 +146,7 @@ const Swap: React.FC = () => {
     orderType === Operation.CLOSE_SHORT || orderType === Operation.SHORT
       ? UNISWAP_ROUTER02_V2
       : UNISWAP_CONNECTOR[chainId]
-  const underlyingTokenBalance = useTokenBalance(underlyingToken.address)
+  const underlyingTokenBalance = useTokenBalance(entity.underlying.address)
   const { onApprove } = useApprove(tokenAddress, spender)
 
   const handleTypeInput = useCallback(
@@ -192,9 +177,8 @@ const Swap: React.FC = () => {
       let credit = '0'
       let short = '0'
       let size = parsedAmount
-      const base = item.entity.base.quantity.toString()
-      const quote = item.entity.quote.quantity.toString()
-      size = item.entity.isCall ? size : size.mul(quote).div(base)
+      const base = entity.baseValue.raw.toString()
+      const quote = entity.quoteValue.raw.toString()
       let actualPremium = ''
       let spot = ''
       // buy long, Trade.getPremium
@@ -203,15 +187,21 @@ const Swap: React.FC = () => {
           spot = Trade.getSpotPremium(
             base,
             quote,
-            [item.entity.assetAddresses[2], item.entity.assetAddresses[0]],
-            [item.reserves[0], item.reserves[1]]
+            [entity.redeem.address, entity.underlying.address],
+            [
+              lpPair.reserveOf(entity.redeem).raw.toString(),
+              lpPair.reserveOf(entity.underlying).raw.toString(),
+            ]
           ).toString()
           actualPremium = Trade.getPremium(
             size,
             base,
             quote,
-            [item.entity.assetAddresses[2], item.entity.assetAddresses[0]],
-            [item.reserves[0], item.reserves[1]]
+            [entity.redeem.address, entity.underlying.address],
+            [
+              lpPair.reserveOf(entity.redeem).raw.toString(),
+              lpPair.reserveOf(entity.underlying).raw.toString(),
+            ]
           ).toString()
           let spotSize = size.mul(BigNumber.from(spot)).div(parseEther('1'))
           setImpact(
@@ -232,16 +222,23 @@ const Swap: React.FC = () => {
           spot = Trade.getCloseSpotPremium(
             base,
             quote,
-            [item.entity.assetAddresses[0], item.entity.assetAddresses[2]],
-            [item.reserves[1], item.reserves[0]]
+            [entity.underlying.address, entity.redeem.address],
+            [
+              lpPair.reserveOf(entity.underlying).raw.toString(),
+              lpPair.reserveOf(entity.redeem).raw.toString(),
+            ]
           ).toString()
-          let shortSize = size.mul(quote).div(base)
+
+          let shortSize = entity.proportionalShort(size)
           actualPremium = Trade.getClosePremium(
             shortSize,
             base,
             quote,
-            [item.entity.assetAddresses[0], item.entity.assetAddresses[2]],
-            [item.reserves[1], item.reserves[0]]
+            [entity.underlying.address, entity.redeem.address],
+            [
+              lpPair.reserveOf(entity.underlying).raw.toString(),
+              lpPair.reserveOf(entity.redeem).raw.toString(),
+            ]
           ).toString()
           let spotSize = size.mul(BigNumber.from(spot)).div(parseEther('1'))
           setImpact(
@@ -261,14 +258,14 @@ const Swap: React.FC = () => {
         if (parsedAmount.gt(BigNumber.from(0))) {
           let tradeQuote = Trade.getQuote(
             size,
-            item.reserves[0],
-            item.reserves[1]
+            lpPair.reserveOf(entity.redeem).raw.toString(),
+            lpPair.reserveOf(entity.underlying).raw.toString()
           ).toString()
           actualPremium = Trade.getAmountsInPure(
             size,
-            [item.entity.assetAddresses[0], item.entity.assetAddresses[2]],
-            item.reserves[1],
-            item.reserves[0]
+            [entity.underlying.address, entity.redeem.address],
+            lpPair.reserveOf(entity.underlying).raw.toString(),
+            lpPair.reserveOf(entity.redeem).raw.toString()
           )[0].toString()
           setImpact(
             (
@@ -289,14 +286,14 @@ const Swap: React.FC = () => {
         if (parsedAmount.gt(BigNumber.from(0))) {
           let tradeQuote = Trade.getQuote(
             size,
-            item.reserves[0],
-            item.reserves[1]
+            lpPair.reserveOf(entity.redeem).raw.toString(),
+            lpPair.reserveOf(entity.underlying).raw.toString()
           ).toString()
           actualPremium = Trade.getAmountsOutPure(
             size,
-            [item.entity.assetAddresses[2], item.entity.assetAddresses[0]],
-            item.reserves[0],
-            item.reserves[1]
+            [entity.redeem.address, entity.underlying.address],
+            lpPair.reserveOf(entity.redeem).raw.toString(),
+            lpPair.reserveOf(entity.underlying).raw.toString()
           )[1].toString()
           setImpact(
             (
@@ -323,8 +320,8 @@ const Swap: React.FC = () => {
 
   const calculateProportionalShort = useCallback(() => {
     const sizeWei = parsedAmount
-    const base = item.entity.base.quantity.toString()
-    const quote = item.entity.quote.quantity.toString()
+    const base = entity.baseValue.raw.toString()
+    const quote = entity.quoteValue.raw.toString()
     const amount = BigNumber.from(sizeWei).mul(quote).div(base)
     return formatEtherBalance(amount)
   }, [item, parsedAmount])

--- a/app/src/hooks/useTradeExecution.ts
+++ b/app/src/hooks/useTradeExecution.ts
@@ -3,13 +3,14 @@ import { useCallback, useEffect, useState, useRef } from 'react'
 import { Web3Provider } from '@ethersproject/providers'
 
 import { Operation, UNISWAP_FACTORY_V2 } from '@/lib/constants'
-import { Option } from '@/lib/entities/option'
+import { Option, EMPTY_ASSET } from '@/lib/entities/option'
 import { parseEther } from 'ethers/lib/utils'
-import { Asset, Trade, Quantity } from '@/lib/entities'
+import { Trade } from '@/lib/entities'
 import { Uniswap, Trader, Protocol } from '@/lib/index'
 import { SinglePositionParameters, TradeSettings } from '@/lib/types'
 import UniswapV2Factory from '@uniswap/v2-core/build/UniswapV2Factory.json'
 import { useTradeSettings } from '@/hooks/user'
+import { Token, TokenAmount } from '@uniswap/sdk'
 
 import executeTransaction from '@/lib/utils/executeTransaction'
 import useOptionEntities, { OptionEntities } from '@/hooks/useOptionEntities'
@@ -28,17 +29,17 @@ const getTrade = async (
 > => {
   const signer: ethers.Signer = await provider.getSigner()
 
-  const inputAmount: Quantity = new Quantity(
-    new Asset(18), // fix with actual metadata
-    parseEther(quantity.toString())
+  const inputAmount: TokenAmount = new TokenAmount(
+    EMPTY_ASSET, // fix with actual metadata
+    parseEther(quantity.toString()).toString()
   )
-  const outputAmount: Quantity = new Quantity(
-    new Asset(18), // fix with actual metadata
+  const outputAmount: TokenAmount = new TokenAmount(
+    EMPTY_ASSET, // fix with actual metadata
     '0'
   )
 
-  const base = optionEntity.optionParameters.base.quantity
-  const quote = optionEntity.optionParameters.quote.quantity
+  const base = optionEntity.baseValue.raw.toString()
+  const quote = optionEntity.quoteValue.raw.toString()
 
   const path: string[] = []
   const amountsIn: BigNumberish[] = []
@@ -70,14 +71,14 @@ const getTrade = async (
       // For this operation, the user borrows underlyingTokens to use to mint redeemTokens, which are then returned to the pair.
       // This is effectively a swap from redeemTokens to underlyingTokens, but it occurs in the reverse order.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // The amountsOut[1] will tell us how much of the flash loan of underlyingTokens is outstanding.
       trade.amountsOut = await trade.getAmountsOut(
         signer,
         factory,
-        inputAmount.quantity,
+        inputAmount.raw.toString(),
         trade.path
       )
       // With the Pair's reserves, we can calculate all values using pure functions, including the premium.
@@ -93,30 +94,33 @@ const getTrade = async (
       // Going SHORT on an option effectively means holding the SHORT OPTION TOKENS.
       // Purchase them for underlyingTokens from the underlying<>redeem UniswapV2Pair.
       trade.path = [
-        optionEntity.assetAddresses[0], // underlying
-        optionEntity.assetAddresses[2], // redeem
+        optionEntity.underlying.address, // underlying
+        optionEntity.redeem.address, // redeem
       ]
       amountsOut = await trade.getAmountsOut(
         signer,
         factory,
-        trade.inputAmount.quantity,
+        trade.inputAmount.raw.toString(),
         trade.path
       )
-      trade.outputAmount.quantity = amountsOut[1]
+      trade.outputAmount = new TokenAmount(
+        EMPTY_ASSET,
+        amountsOut[1].toString()
+      )
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
     case Operation.CLOSE_LONG:
       // On the UI, the user inputs the quantity of LONG OPTIONS they want to close.
       // Calling the function on the contract requires the quantity of SHORT OPTIONS being borrowed to close.
       // Need to calculate how many SHORT OPTIONS are needed to close the desired quantity of LONG OPTIONS.
-      const redeemAmount = ethers.BigNumber.from(inputAmount.quantity)
+      const redeemAmount = ethers.BigNumber.from(inputAmount.raw.toString())
         .mul(quote)
         .div(base)
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[0], // underlying
-        optionEntity.assetAddresses[2], // redeem
+        optionEntity.underlying.address, // underlying
+        optionEntity.redeem.address, // redeem
       ]
       // The amountIn[0] will tell how many underlyingTokens are needed for the borrowed amount of redeemTokens.
       trade.amountsIn = await trade.getAmountsIn(
@@ -133,33 +137,36 @@ const getTrade = async (
         trade.path[1]
       )
       // The actual function will take the redeemQuantity rather than the optionQuantity.
-      trade.inputAmount.quantity = redeemAmount
+      trade.inputAmount = new TokenAmount(EMPTY_ASSET, redeemAmount.toString())
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
     case Operation.CLOSE_SHORT:
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // The amountIn[0] will tell how many underlyingTokens are needed for the borrowed amount of redeemTokens.
       trade.amountsOut = await trade.getAmountsOut(
         signer,
         factory,
-        trade.inputAmount.quantity,
+        trade.inputAmount.raw.toString(),
         trade.path
       )
       // The actual function will take the redeemQuantity rather than the optionQuantity.
-      trade.outputAmount.quantity = trade.amountsOut[1]
+      trade.outputAmount = new TokenAmount(
+        EMPTY_ASSET,
+        trade.amountsOut[1].toString()
+      )
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
     case Operation.ADD_LIQUIDITY:
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
       trade.reserves = await trade.getReserves(
@@ -170,9 +177,11 @@ const getTrade = async (
       )
 
       // The actual function will take the redeemQuantity rather than the optionQuantity.
-      trade.outputAmount = new Quantity(
-        new Asset(18), // fix with actual metadata
-        parseEther(secondaryQuantity ? secondaryQuantity.toString() : '0')
+      trade.outputAmount = new TokenAmount(
+        EMPTY_ASSET, // fix with actual metadata
+        parseEther(
+          secondaryQuantity ? secondaryQuantity.toString() : '0'
+        ).toString()
       )
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
@@ -180,8 +189,8 @@ const getTrade = async (
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
       trade.reserves = await trade.getReserves(
@@ -205,8 +214,8 @@ const getTrade = async (
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
       trade.reserves = await trade.getReserves(

--- a/app/src/hooks/useTradeInfo.ts
+++ b/app/src/hooks/useTradeInfo.ts
@@ -4,9 +4,9 @@ import { Web3Provider } from '@ethersproject/providers'
 
 import { Operation } from '@/constants/index'
 import { UNISWAP_FACTORY_V2 } from '@/lib/constants'
-import { Option } from '@/lib/entities/option'
+import { Option, EMPTY_ASSET } from '@/lib/entities/option'
 import { parseEther } from 'ethers/lib/utils'
-import { Asset, Trade, Quantity } from '@/lib/entities'
+import { Trade } from '@/lib/entities'
 import { Uniswap, Trader, Protocol } from '@/lib/index'
 import { TradeSettings } from '@/lib/types'
 import UniswapV2Factory from '@uniswap/v2-core/build/UniswapV2Factory.json'
@@ -16,6 +16,8 @@ import executeTransaction from '@/lib/utils/executeTransaction'
 import useOptionEntities, { OptionEntities } from '@/hooks/useOptionEntities'
 import { useTransactionAdder } from '@/state/transactions/hooks'
 import { useItem } from '@/state/order/hooks'
+
+import { Token, TokenAmount } from '@uniswap/sdk'
 
 import { useWeb3React } from '@web3-react/core'
 
@@ -32,17 +34,17 @@ const getTrade = async (
 > => {
   const signer: ethers.Signer = await provider.getSigner()
 
-  const inputAmount: Quantity = new Quantity(
-    new Asset(18), // fix with actual metadata
-    parseEther(quantity.toString())
+  const inputAmount: TokenAmount = new TokenAmount(
+    EMPTY_ASSET, // fix with actual metadata
+    parseEther(quantity.toString()).toString()
   )
-  const outputAmount: Quantity = new Quantity(
-    new Asset(18), // fix with actual metadata
+  const outputAmount: TokenAmount = new TokenAmount(
+    EMPTY_ASSET, // fix with actual metadata
     '0'
   )
 
-  const base = optionEntity.optionParameters.base.quantity
-  const quote = optionEntity.optionParameters.quote.quantity
+  const base = optionEntity.baseValue.raw.toString()
+  const quote = optionEntity.quoteValue.raw.toString()
 
   const path: string[] = []
   const amountsIn: BigNumberish[] = []
@@ -74,14 +76,14 @@ const getTrade = async (
       // For this operation, the user borrows underlyingTokens to use to mint redeemTokens, which are then returned to the pair.
       // This is effectively a swap from redeemTokens to underlyingTokens, but it occurs in the reverse order.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // The amountsOut[1] will tell us how much of the flash loan of underlyingTokens is outstanding.
       trade.amountsOut = await trade.getAmountsOut(
         signer,
         factory,
-        inputAmount.quantity,
+        inputAmount.raw.toString(),
         trade.path
       )
       // With the Pair's reserves, we can calculate all values using pure functions, including the premium.
@@ -97,30 +99,33 @@ const getTrade = async (
       // Going SHORT on an option effectively means holding the SHORT OPTION TOKENS.
       // Purchase them for underlyingTokens from the underlying<>redeem UniswapV2Pair.
       trade.path = [
-        optionEntity.assetAddresses[0], // underlying
-        optionEntity.assetAddresses[2], // redeem
+        optionEntity.underlying.address, // underlying
+        optionEntity.redeem.address, // redeem
       ]
       amountsOut = await trade.getAmountsOut(
         signer,
         factory,
-        trade.inputAmount.quantity,
+        trade.inputAmount.raw.toString(),
         trade.path
       )
-      trade.outputAmount.quantity = amountsOut[1]
+      trade.outputAmount = new TokenAmount(
+        EMPTY_ASSET,
+        amountsOut[1].toString()
+      )
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
     case Operation.CLOSE_LONG:
       // On the UI, the user inputs the quantity of LONG OPTIONS they want to close.
       // Calling the function on the contract requires the quantity of SHORT OPTIONS being borrowed to close.
       // Need to calculate how many SHORT OPTIONS are needed to close the desired quantity of LONG OPTIONS.
-      const redeemAmount = ethers.BigNumber.from(inputAmount.quantity)
+      const redeemAmount = ethers.BigNumber.from(inputAmount.raw.toString())
         .mul(quote)
         .div(base)
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[0], // underlying
-        optionEntity.assetAddresses[2], // redeem
+        optionEntity.underlying.address, // underlying
+        optionEntity.redeem.address, // redeem
       ]
       // The amountIn[0] will tell how many underlyingTokens are needed for the borrowed amount of redeemTokens.
       trade.amountsIn = await trade.getAmountsIn(
@@ -137,33 +142,36 @@ const getTrade = async (
         trade.path[1]
       )
       // The actual function will take the redeemQuantity rather than the optionQuantity.
-      trade.inputAmount.quantity = redeemAmount
+      trade.inputAmount = new TokenAmount(EMPTY_ASSET, redeemAmount.toString())
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
     case Operation.CLOSE_SHORT:
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // The amountIn[0] will tell how many underlyingTokens are needed for the borrowed amount of redeemTokens.
       trade.amountsOut = await trade.getAmountsOut(
         signer,
         factory,
-        trade.inputAmount.quantity,
+        trade.inputAmount.raw.toString(),
         trade.path
       )
       // The actual function will take the redeemQuantity rather than the optionQuantity.
-      trade.outputAmount.quantity = trade.amountsOut[1]
+      trade.outputAmount = new TokenAmount(
+        EMPTY_ASSET,
+        trade.amountsOut[1].toString()
+      )
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
     case Operation.ADD_LIQUIDITY:
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
       trade.reserves = await trade.getReserves(
@@ -174,9 +182,11 @@ const getTrade = async (
       )
 
       // The actual function will take the redeemQuantity rather than the optionQuantity.
-      trade.outputAmount = new Quantity(
-        new Asset(18), // fix with actual metadata
-        parseEther(secondaryQuantity ? secondaryQuantity.toString() : '0')
+      trade.outputAmount = new TokenAmount(
+        EMPTY_ASSET, // fix with actual metadata
+        parseEther(
+          secondaryQuantity ? secondaryQuantity.toString() : '0'
+        ).toString()
       )
       //transaction = Uniswap.singlePositionCallParameters(trade, tradeSettings)
       break
@@ -184,8 +194,8 @@ const getTrade = async (
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
       trade.reserves = await trade.getReserves(
@@ -209,8 +219,8 @@ const getTrade = async (
       // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
       // with the path of underlyingTokens to redeemTokens.
       trade.path = [
-        optionEntity.assetAddresses[2], // redeem
-        optionEntity.assetAddresses[0], // underlying
+        optionEntity.redeem.address, // redeem
+        optionEntity.underlying.address, // underlying
       ]
       // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
       trade.reserves = await trade.getReserves(

--- a/app/src/lib/entities/option.ts
+++ b/app/src/lib/entities/option.ts
@@ -1,24 +1,21 @@
-// import { Token } from './token' breaks Pair types
-import { Asset } from './asset'
-import { Quantity } from './quantity'
 import ethers, { BigNumberish, BigNumber } from 'ethers'
 import OptionArtifact from '@primitivefi/contracts/artifacts/Option.json'
-import { formatEther } from 'ethers/lib/utils'
-import { Pair, Token } from '@uniswap/sdk'
-import { STABLECOINS } from '@/constants/index'
+import { formatEther, parseEther } from 'ethers/lib/utils'
+import { Pair, Token, TokenAmount } from '@uniswap/sdk'
+import { STABLECOINS, ADDRESS_ZERO } from '@/constants/index'
 import isZero from '@/utils/isZero'
 
 export interface OptionParameters {
-  base: Quantity
-  quote: Quantity
+  base: TokenAmount
+  quote: TokenAmount
   expiry: number
 }
 
-export const EMPTY_ASSET: Asset = new Asset(18)
-export const EMPTY_QUANTITY: Quantity = new Quantity(EMPTY_ASSET, '')
+export const EMPTY_ASSET: Token = new Token(1, ADDRESS_ZERO, 18)
+export const EMPTY_TOKEN_AMOUNT: TokenAmount = new TokenAmount(EMPTY_ASSET, '')
 export const EMPTY_OPTION_PARAMETERS: OptionParameters = {
-  base: EMPTY_QUANTITY,
-  quote: EMPTY_QUANTITY,
+  base: EMPTY_TOKEN_AMOUNT,
+  quote: EMPTY_TOKEN_AMOUNT,
   expiry: 0,
 }
 
@@ -41,7 +38,8 @@ export const createOptionEntityWithAddress = (
  */
 export class Option extends Token {
   public readonly optionParameters: OptionParameters
-  public assetAddresses: string[]
+  public tokenAddresses: string[]
+  public pair: Pair
   public constructor(
     optionParameters: OptionParameters,
     chainId: number,
@@ -54,98 +52,98 @@ export class Option extends Token {
     this.optionParameters = optionParameters
   }
 
-  public setAssetAddresses(assets) {
-    this.assetAddresses = assets
+  public setTokenAddresses(assets) {
+    this.tokenAddresses = assets
   }
 
   public optionInstance(signer): ethers.Contract {
     return new ethers.Contract(this.address, OptionArtifact.abi, signer)
   }
 
-  public get pair(): string {
-    const SHORT_OPTION: Token = new Token(
-      this.chainId,
-      this.assetAddresses[2],
-      18
-    )
-    const UNDERLYING: Token = new Token(
-      this.chainId,
-      this.assetAddresses[0],
-      18
-    )
-    const address: string = Pair.getAddress(UNDERLYING, SHORT_OPTION)
-
+  public get pairAddress(): string {
+    const address: string = Pair.getAddress(this.underlying, this.redeem)
     return address
   }
 
-  public get underlying(): Asset {
-    return this.optionParameters.base.asset
+  public setPair(pair: Pair) {
+    this.pair = pair
   }
 
-  public get strike(): Asset {
-    return this.optionParameters.quote.asset
+  public get underlying(): Token {
+    return this.optionParameters.base.token
   }
 
-  public get base(): Quantity {
+  public get strike(): Token {
+    return this.optionParameters.quote.token
+  }
+
+  public get baseValue(): TokenAmount {
     return this.optionParameters.base
   }
 
-  public get quote(): Quantity {
+  public get quoteValue(): TokenAmount {
     return this.optionParameters.quote
   }
 
-  public get expiry(): number {
+  public get expiryValue(): number {
     return this.optionParameters.expiry
   }
 
-  public get strikePrice(): Quantity {
-    const baseValue = this.optionParameters.base.quantity
-    const quoteValue = this.optionParameters.quote.quantity
-    let strikePrice: Quantity
-    if (baseValue === '1') {
-      strikePrice = this.optionParameters.quote
-    } else if (quoteValue === '1') {
-      strikePrice = this.optionParameters.base
+  public get redeem(): Token {
+    return new Token(
+      this.chainId,
+      this.tokenAddresses[2],
+      18,
+      'RDM',
+      'Primitive V1 Redeem'
+    )
+  }
+
+  public get strikePrice(): string {
+    const baseValue = this.baseValue.raw.toString()
+    const quoteValue = this.quoteValue.raw.toString()
+    const numerator = BigNumber.from(quoteValue)
+    const denominator = BigNumber.from(baseValue)
+    let strikePrice: string
+    if (parseEther('1').eq(baseValue)) {
+      strikePrice = (parseInt(quoteValue) / parseInt(baseValue)).toString()
+    } else if (parseEther('1').eq(quoteValue)) {
+      strikePrice = (parseInt(baseValue) / parseInt(quoteValue)).toString()
     } else {
-      const numerator = BigNumber.from(quoteValue)
-      const denominator = BigNumber.from(baseValue)
-      if (isZero(denominator))
-        return new Quantity(
-          this.optionParameters.quote.asset,
-          BigNumber.from('0')
-        )
+      if (isZero(denominator)) return '0'
 
       const strike =
         parseInt(numerator.toString()) / parseInt(denominator.toString())
 
-      strikePrice = new Quantity(this.optionParameters.quote.asset, strike)
+      strikePrice = strike.toString()
     }
+
     return strikePrice
   }
 
   public proportionalLong(quantityShort: BigNumberish): BigNumber {
-    const numerator = this.optionParameters.base.quantity
-    const denominator = this.optionParameters.quote.quantity
+    const numerator = this.baseValue.raw.toString()
+    const denominator = this.quoteValue.raw.toString()
     if (isZero(denominator)) return BigNumber.from('0')
-    const strike = BigNumber.from(quantityShort).mul(numerator).div(denominator)
-    return strike
+    const long = BigNumber.from(quantityShort).mul(numerator).div(denominator)
+    return long
   }
 
   public proportionalShort(quantityLong: BigNumberish): BigNumber {
-    const numerator = this.optionParameters.quote.quantity
-    const denominator = this.optionParameters.base.quantity
+    const numerator = this.quoteValue.raw.toString()
+    const denominator = this.baseValue.raw.toString()
     if (isZero(denominator)) return BigNumber.from('0')
-    const strike = BigNumber.from(quantityLong).mul(numerator).div(denominator)
-    return strike
+    const short = BigNumber.from(quantityLong).mul(numerator).div(denominator)
+    return short
   }
 
   public get isCall(): boolean {
-    const baseValue = this.optionParameters.base.quantity
-    const quoteValue = this.optionParameters.quote.quantity
+    const baseValue = this.baseValue.raw.toString()
+    const quoteValue = this.quoteValue.raw.toString()
     let isCall = false
     if (+formatEther(baseValue) === 1) {
       if (+formatEther(quoteValue) === 1) {
-        const quoteToken = this.optionParameters.base.asset.symbol
+        const quoteToken = this.underlying.symbol
         if (quoteToken === STABLECOINS[this.chainId].symbol) {
           isCall = true
         }
@@ -157,12 +155,12 @@ export class Option extends Token {
   }
 
   public get isPut(): boolean {
-    const quoteValue = this.optionParameters.quote.quantity
-    const baseValue = this.optionParameters.base.quantity
+    const quoteValue = this.quoteValue.raw.toString()
+    const baseValue = this.baseValue.raw.toString()
     let isPut = false
     if (+formatEther(quoteValue) === 1) {
       if (+formatEther(baseValue) === 1) {
-        const baseToken = this.optionParameters.quote.asset.symbol
+        const baseToken = this.strike.symbol
         if (baseToken === STABLECOINS[this.chainId].symbol) {
           isPut = true
         }
@@ -170,12 +168,11 @@ export class Option extends Token {
         isPut = true
       }
     }
-
     return isPut
   }
 
   public getTimeToExpiry(): number {
-    const expiry: number = this.optionParameters.expiry * 1000
+    const expiry: number = this.expiryValue * 1000
     const now: number = new Date().valueOf()
     const secondsInYear = 60 * 60 * 24 * 365
     const timeLeft: number = (expiry - now) / secondsInYear

--- a/app/src/lib/math/blackscholes.ts
+++ b/app/src/lib/math/blackscholes.ts
@@ -121,7 +121,7 @@ export class BlackScholes implements BlackScholesInterface {
         (2 * Math.sqrt(this.option.getTimeToExpiry())) -
       sign *
         this.riskFree *
-        +this.option.strikePrice.quantity *
+        +this.option.strikePrice *
         Math.exp(-1 * this.riskFree * this.option.getTimeToExpiry()) *
         NormalDistribution.pdf(sign * this.d2)
 
@@ -143,7 +143,7 @@ export class BlackScholes implements BlackScholesInterface {
 
     const rho =
       sign *
-      +this.option.strikePrice.quantity *
+      +this.option.strikePrice *
       expiryTime *
       Math.exp(-1 * this.riskFree * expiryTime) *
       NormalDistribution.cdf(sign * this.d2)
@@ -189,15 +189,12 @@ export class BlackScholes implements BlackScholesInterface {
     const sign = this.option.isCall ? 1 : -1
 
     if (this.option.getTimeToExpiry() < minTimeToExpire) {
-      return Math.max(
-        sign * (this.assetPrice - +this.option.strikePrice.quantity),
-        0
-      )
+      return Math.max(sign * (this.assetPrice - +this.option.strikePrice), 0)
     }
 
     const priceNorm = this.assetPrice * NormalDistribution.cdf(sign * this.d1)
     const strikeRisk =
-      +this.option.strikePrice.quantity *
+      +this.option.strikePrice *
       Math.exp(-1 * this.riskFree * this.option.getTimeToExpiry()) *
       NormalDistribution.cdf(sign * this.d2)
 
@@ -216,7 +213,7 @@ export class BlackScholes implements BlackScholesInterface {
     }
 
     return (
-      (Math.log(this.assetPrice / +this.option.strikePrice.quantity) +
+      (Math.log(this.assetPrice / +this.option.strikePrice) +
         (this.riskFree + Math.pow(this.deviation, 2) / 2) * timeToExpiry) /
       (this.deviation * Math.sqrt(timeToExpiry))
     )
@@ -257,7 +254,7 @@ export class BlackScholes implements BlackScholesInterface {
       ) */
       var actualCost = this.blackScholes(
         this.assetPrice,
-        this.option.strikePrice.quantity,
+        this.option.strikePrice,
         this.option.getTimeToExpiry(),
         estimate,
         this.riskFree,

--- a/app/src/lib/trader.ts
+++ b/app/src/lib/trader.ts
@@ -35,12 +35,12 @@ export class Trader {
     let value: string
 
     const optionAddress: string = trade.option.address
-    const amountIn: string = trade.inputAmount.quantity.toString()
+    const amountIn: string = trade.inputAmount.raw.toString()
     const to: string = tradeSettings.receiver
 
     const parameters = trade.option.optionParameters
-    const isWethCall = parameters.base.asset.symbol === 'ETHER'
-    const isWethPut = parameters.quote.asset.symbol === 'ETHER'
+    const isWethCall = parameters.base.token.symbol === 'ETHER'
+    const isWethPut = parameters.quote.token.symbol === 'ETHER'
 
     switch (trade.operation) {
       case Operation.MINT:

--- a/app/src/lib/uniswap.ts
+++ b/app/src/lib/uniswap.ts
@@ -44,9 +44,8 @@ export class Uniswap {
           ).toString()
         : tradeSettings.deadline.toString()
     const to: string = tradeSettings.receiver
-    const baseValue: BigNumberish = trade.option.optionParameters.base.quantity
-    const quoteValue: BigNumberish =
-      trade.option.optionParameters.quote.quantity
+    const baseValue: BigNumberish = trade.option.baseValue.raw.toString()
+    const quoteValue: BigNumberish = trade.option.quoteValue.raw.toString()
 
     const UniswapV2Router02Contract = new ethers.Contract(
       UNISWAP_ROUTER02_V2,
@@ -60,7 +59,7 @@ export class Uniswap {
       trade.signer
     )
 
-    const inputAmount: string = trade.inputAmount.quantity.toString()
+    const inputAmount: string = trade.inputAmount.raw.toString()
 
     switch (trade.operation) {
       case Operation.LONG:
@@ -130,12 +129,10 @@ export class Uniswap {
         break
       case Operation.CLOSE_SHORT:
         // Just purchase redeemTokens from a redeem<>underlying token pair
-        amountIn = trade
-          .maximumAmountIn(tradeSettings.slippage)
-          .quantity.toString()
+        amountIn = trade.maximumAmountIn(tradeSettings.slippage).raw.toString()
         const amountOutMin = trade
           .minimumAmountOut(tradeSettings.slippage)
-          .quantity.toString()
+          .raw.toString()
 
         contract = UniswapV2Router02Contract
         methodName = 'swapExactTokensForTokens'
@@ -162,7 +159,7 @@ export class Uniswap {
         amountADesired = trade.option.proportionalShort(optionsInput)
 
         if (isZero(trade.reserves[0]) && isZero(trade.reserves[1])) {
-          amountBDesired = trade.outputAmount.quantity.toString()
+          amountBDesired = trade.outputAmount.raw.toString()
         } else {
           amountBDesired = trade
             .quote(amountADesired, trade.reserves[0], trade.reserves[1])
@@ -191,7 +188,7 @@ export class Uniswap {
       case Operation.ADD_LIQUIDITY_CUSTOM:
         // amount of redeems that will be minted and added to the pool
         amountADesired = trade.option.proportionalShort(inputAmount)
-        amountBDesired = trade.outputAmount.quantity.toString()
+        amountBDesired = trade.outputAmount.raw.toString()
 
         amountAMin = trade.calcMinimumOutSlippage(
           amountADesired,
@@ -207,7 +204,7 @@ export class Uniswap {
           trade.path[0],
           trade.path[1],
           inputAmount,
-          trade.outputAmount.quantity.toString(),
+          trade.outputAmount.raw.toString(),
           amountAMin.toString(),
           amountBMin.toString(),
           to,
@@ -241,7 +238,7 @@ export class Uniswap {
           trade.path[0],
           trade.path[1],
           inputAmount,
-          trade.outputAmount.quantity.toString(),
+          trade.outputAmount.raw.toString(),
           amountAMin.toString(),
           amountBMin.toString(),
           to,

--- a/app/src/state/order/hooks.tsx
+++ b/app/src/state/order/hooks.tsx
@@ -15,13 +15,14 @@ import {
   DEFAULT_TIMELIMIT,
   STABLECOINS,
   DEFAULT_ALLOWANCE,
+  ADDRESS_ZERO,
 } from '@/constants/index'
 
 import { UNISWAP_FACTORY_V2 } from '@/lib/constants'
 import { UNISWAP_ROUTER02_V2 } from '@/lib/constants'
 import { Option, createOptionEntityWithAddress } from '@/lib/entities/option'
 import { parseEther, formatEther } from 'ethers/lib/utils'
-import { Asset, Trade, Quantity } from '@/lib/entities'
+import { Trade } from '@/lib/entities'
 import { Trader } from '@/lib/trader'
 import { Uniswap } from '@/lib/uniswap'
 import { TradeSettings, SinglePositionParameters } from '@/lib/types'
@@ -42,6 +43,8 @@ import { useTransactionAdder } from '@/state/transactions/hooks'
 import { useAddNotif } from '@/state/notifs/hooks'
 import { useClearSwap } from '@/state/swap/hooks'
 import { useClearLP } from '@/state/liquidity/hooks'
+
+const EMPTY_TOKEN: Token = new Token(1, ADDRESS_ZERO, 18)
 
 export const useItem = (): {
   item: OptionsAttributes
@@ -66,12 +69,7 @@ export const useUpdateItem = (): ((
   const clearLP = useClearLP()
   return useCallback(
     async (item: OptionsAttributes, orderType: Operation, lpPair?: Pair) => {
-      const underlyingToken: Token = new Token(
-        item.entity.chainId,
-        item.entity.assetAddresses[0],
-        18,
-        item.entity.isPut ? 'DAI' : item.asset.toUpperCase()
-      )
+      const underlyingToken: Token = item.entity.underlying
       let manage = false
       switch (orderType) {
         case Operation.MINT:
@@ -109,7 +107,7 @@ export const useUpdateItem = (): ((
           const spender = UNISWAP_CONNECTOR[chainId]
           if (orderType === Operation.ADD_LIQUIDITY) {
             const tokenAllowance = await getAllowance(
-              item.entity.assetAddresses[0],
+              item.entity.tokenAddresses[0],
               spender
             )
             dispatch(
@@ -149,13 +147,13 @@ export const useUpdateItem = (): ((
               tokenAddress = underlyingToken.address
               break
             case Operation.EXERCISE:
-              tokenAddress = item.entity.address // item.entity.assetAddresses[1] FIX DOUBLE APPROVAL
+              tokenAddress = item.entity.address // item.entity.tokenAddresses[1] FIX DOUBLE APPROVAL
               break
             case Operation.REDEEM:
-              tokenAddress = item.entity.assetAddresses[2]
+              tokenAddress = item.entity.redeem.address
               break
             case Operation.CLOSE:
-              tokenAddress = item.entity.address // item.entity.assetAddresses[2] FIX DOUBLE APPROVAL
+              tokenAddress = item.entity.address // item.entity.tokenAddresses[2] FIX DOUBLE APPROVAL
               break
             default:
               break
@@ -191,7 +189,7 @@ export const useUpdateItem = (): ((
               tokenAddress = item.entity.address
               break
             case Operation.CLOSE_SHORT:
-              tokenAddress = item.entity.assetAddresses[2]
+              tokenAddress = item.entity.redeem.address
               break
             default:
               tokenAddress = underlyingToken.address
@@ -260,23 +258,29 @@ export const useHandleSubmitOrder = (): ((
       )
 
       //console.log(parseInt(quantity) * 1000000000000000000)
-      const inputAmount: Quantity = new Quantity(
-        new Asset(18), // fix with actual metadata
-        BigNumber.from(BigInt(quantity.toString()).toString())
+      const inputAmount: TokenAmount = new TokenAmount(
+        EMPTY_TOKEN, // fix with actual metadata
+        BigInt(quantity.toString()).toString()
       )
-      const outputAmount: Quantity = new Quantity(
-        new Asset(18), // fix with actual metadata
-        BigNumber.from('0')
+      const outputAmount: TokenAmount = new TokenAmount(
+        EMPTY_TOKEN, // fix with actual metadata
+        '0'
       )
       const optionInstance: ethers.Contract = optionEntity.optionInstance(
         signer
       )
       const base: ethers.BigNumber = await optionInstance.getBaseValue()
       const quote: ethers.BigNumber = await optionInstance.getQuoteValue()
-      const assetAddresses: string[] = await optionInstance.getAssetAddresses()
-      optionEntity.setAssetAddresses(assetAddresses)
-      optionEntity.optionParameters.base = new Quantity(new Asset(18), base)
-      optionEntity.optionParameters.quote = new Quantity(new Asset(18), quote)
+      const tokenAddresses: string[] = await optionInstance.getAssetAddresses()
+      optionEntity.setTokenAddresses(tokenAddresses)
+      optionEntity.optionParameters.base = new TokenAmount(
+        EMPTY_TOKEN,
+        base.toString()
+      )
+      optionEntity.optionParameters.quote = new TokenAmount(
+        EMPTY_TOKEN,
+        quote.toString()
+      )
       let out: BigNumberish
       const path: string[] = []
       const amountsIn: BigNumberish[] = []
@@ -307,14 +311,14 @@ export const useHandleSubmitOrder = (): ((
           // For this operation, the user borrows underlyingTokens to use to mint redeemTokens, which are then returned to the pair.
           // This is effectively a swap from redeemTokens to underlyingTokens, but it occurs in the reverse order.
           trade.path = [
-            assetAddresses[2], // redeem
-            assetAddresses[0], // underlying
+            tokenAddresses[2], // redeem
+            tokenAddresses[0], // underlying
           ]
           // The amountsOut[1] will tell us how much of the flash loan of underlyingTokens is outstanding.
           trade.amountsOut = await trade.getAmountsOut(
             signer,
             factory,
-            inputAmount.quantity,
+            inputAmount.raw.toString(),
             trade.path
           )
           // With the Pair's reserves, we can calculate all values using pure functions, including the premium.
@@ -333,8 +337,8 @@ export const useHandleSubmitOrder = (): ((
           // Going SHORT on an option effectively means holding the SHORT OPTION TOKENS.
           // Purchase them for underlyingTokens from the underlying<>redeem UniswapV2Pair.
           trade.path = [
-            assetAddresses[0], // underlying
-            assetAddresses[2], // redeem
+            tokenAddresses[0], // underlying
+            tokenAddresses[2], // redeem
           ]
           trade.reserves = await trade.getReserves(
             signer,
@@ -345,10 +349,13 @@ export const useHandleSubmitOrder = (): ((
           amountsOut = await trade.getAmountsOut(
             signer,
             factory,
-            trade.inputAmount.quantity,
+            trade.inputAmount.raw.toString(),
             trade.path
           )
-          trade.outputAmount.quantity = amountsOut[1]
+          trade.outputAmount = new TokenAmount(
+            EMPTY_TOKEN,
+            amountsOut[1].toString()
+          )
           transaction = Uniswap.singlePositionCallParameters(
             trade,
             tradeSettings
@@ -356,8 +363,8 @@ export const useHandleSubmitOrder = (): ((
           break
         case Operation.WRITE:
           trade.path = [
-            assetAddresses[0], // underlying
-            assetAddresses[2], // redeem
+            tokenAddresses[0], // underlying
+            tokenAddresses[2], // redeem
           ]
           // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
           trade.reserves = await trade.getReserves(
@@ -375,14 +382,14 @@ export const useHandleSubmitOrder = (): ((
           // On the UI, the user inputs the quantity of LONG OPTIONS they want to close.
           // Calling the function on the contract requires the quantity of SHORT OPTIONS being borrowed to close.
           // Need to calculate how many SHORT OPTIONS are needed to close the desired quantity of LONG OPTIONS.
-          const redeemAmount = ethers.BigNumber.from(inputAmount.quantity)
+          const redeemAmount = ethers.BigNumber.from(inputAmount.raw.toString())
             .mul(quote)
             .div(base)
           // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
           // with the path of underlyingTokens to redeemTokens.
           trade.path = [
-            assetAddresses[0], // underlying
-            assetAddresses[2], // redeem
+            tokenAddresses[0], // underlying
+            tokenAddresses[2], // redeem
           ]
           // The amountIn[0] will tell how many underlyingTokens are needed for the borrowed amount of redeemTokens.
           trade.amountsIn = await trade.getAmountsIn(
@@ -399,7 +406,10 @@ export const useHandleSubmitOrder = (): ((
             trade.path[1]
           )
           // The actual function will take the redeemQuantity rather than the optionQuantity.
-          trade.inputAmount.quantity = redeemAmount
+          trade.inputAmount = new TokenAmount(
+            EMPTY_TOKEN,
+            redeemAmount.toString()
+          )
           transaction = Uniswap.singlePositionCallParameters(
             trade,
             tradeSettings
@@ -409,18 +419,21 @@ export const useHandleSubmitOrder = (): ((
           // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
           // with the path of underlyingTokens to redeemTokens.
           trade.path = [
-            assetAddresses[2], // redeem
-            assetAddresses[0], // underlying
+            tokenAddresses[2], // redeem
+            tokenAddresses[0], // underlying
           ]
           // The amountIn[0] will tell how many underlyingTokens are needed for the borrowed amount of redeemTokens.
           trade.amountsOut = await trade.getAmountsOut(
             signer,
             factory,
-            trade.inputAmount.quantity,
+            trade.inputAmount.raw.toString(),
             trade.path
           )
           // The actual function will take the redeemQuantity rather than the optionQuantity.
-          trade.outputAmount.quantity = trade.amountsOut[1]
+          trade.outputAmount = new TokenAmount(
+            EMPTY_TOKEN,
+            trade.amountsOut[1].toString()
+          )
           transaction = Uniswap.singlePositionCallParameters(
             trade,
             tradeSettings
@@ -430,8 +443,8 @@ export const useHandleSubmitOrder = (): ((
           // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
           // with the path of underlyingTokens to redeemTokens.
           trade.path = [
-            assetAddresses[2], // redeem
-            assetAddresses[0], // underlying
+            tokenAddresses[2], // redeem
+            tokenAddresses[0], // underlying
           ]
           // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
           trade.reserves = await trade.getReserves(
@@ -447,9 +460,9 @@ export const useHandleSubmitOrder = (): ((
               : BigNumber.from('0')
 
           console.log(out.toString())
-          trade.outputAmount = new Quantity(
-            new Asset(18), // fix with actual metadata
-            out
+          trade.outputAmount = new TokenAmount(
+            EMPTY_TOKEN, // fix with actual metadata
+            out.toString()
           )
 
           transaction = Uniswap.singlePositionCallParameters(
@@ -461,8 +474,8 @@ export const useHandleSubmitOrder = (): ((
           // This function borrows redeem tokens and pays back in underlying tokens. This is a normal swap
           // with the path of underlyingTokens to redeemTokens.
           trade.path = [
-            assetAddresses[2], // redeem
-            assetAddresses[0], // underlying
+            tokenAddresses[2], // redeem
+            tokenAddresses[0], // underlying
           ]
           // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
           trade.reserves = await trade.getReserves(
@@ -477,9 +490,9 @@ export const useHandleSubmitOrder = (): ((
               ? BigNumber.from(secondaryQuantity.toString())
               : BigNumber.from('0')
 
-          trade.outputAmount = new Quantity(
-            new Asset(18), // fix with actual metadata
-            out
+          trade.outputAmount = new TokenAmount(
+            EMPTY_TOKEN, // fix with actual metadata
+            out.toString()
           )
 
           transaction = Uniswap.singlePositionCallParameters(
@@ -489,8 +502,8 @@ export const useHandleSubmitOrder = (): ((
           break
         case Operation.REMOVE_LIQUIDITY:
           trade.path = [
-            assetAddresses[2], // redeem
-            assetAddresses[0], // underlying
+            tokenAddresses[2], // redeem
+            tokenAddresses[0], // underlying
           ]
           // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
           trade.reserves = await trade.getReserves(
@@ -515,8 +528,8 @@ export const useHandleSubmitOrder = (): ((
           break
         case Operation.REMOVE_LIQUIDITY_CLOSE:
           trade.path = [
-            assetAddresses[2], // redeem
-            assetAddresses[0], // underlying
+            tokenAddresses[2], // redeem
+            tokenAddresses[0], // underlying
           ]
           // Get the reserves here because we have the web3 context. With the reserves, we can calulcate all token outputs.
           trade.reserves = await trade.getReserves(

--- a/app/src/state/positions/hooks.tsx
+++ b/app/src/state/positions/hooks.tsx
@@ -11,12 +11,12 @@ import { useOptions } from '@/state/options/hooks'
 import { OptionsAttributes } from '../options/reducer'
 import { getBalance } from '@/lib/erc20'
 import formatEtherBalance from '@/utils/formatEtherBalance'
-import { Quantity, Asset } from '@/lib/entities'
+import { TokenAmount } from '@uniswap/sdk'
 
 export const usePositions = (): {
   loading: boolean
   exists: boolean
-  balance: Quantity
+  balance: TokenAmount
   options: OptionPosition[]
 } => {
   const state = useSelector<AppState, AppState['positions']>(
@@ -53,11 +53,14 @@ export const useUpdatePositions = (): ((
       }
       const bal = await getBalance(
         library,
-        options[0].entity.assetAddresses[0],
+        options[0].entity.underlying.address,
         account
       )
 
-      const balance = new Quantity(options[0].entity.base.asset, bal)
+      const balance = new TokenAmount(
+        options[0].entity.underlying,
+        bal.toString()
+      )
       // underlying balance
 
       for (let i = 0; i < options.length; i++) {
@@ -69,11 +72,15 @@ export const useUpdatePositions = (): ((
 
         const redeem = await getBalance(
           library,
-          options[i].entity.assetAddresses[2],
+          options[i].entity.redeem.address,
           account
         )
 
-        const lp = await getBalance(library, options[i].entity.pair, account)
+        const lp = await getBalance(
+          library,
+          options[i].entity.pairAddress,
+          account
+        )
         if (
           formatEtherBalance(long) !== '0.00' ||
           formatEtherBalance(redeem) !== '0.00' ||

--- a/app/src/state/positions/reducer.ts
+++ b/app/src/state/positions/reducer.ts
@@ -2,14 +2,14 @@ import { createReducer } from '@reduxjs/toolkit'
 
 import { updatePositions, setLoading } from './actions'
 
-import { Quantity } from '@/lib/entities'
+import { TokenAmount } from '@uniswap/sdk'
 import { BigNumberish } from 'ethers'
 import { OptionsAttributes, EmptyAttributes } from '@/state/options/reducer'
 
 export interface PositionsState {
   loading: boolean
   exists: boolean
-  balance: Quantity
+  balance: TokenAmount
   options: OptionPosition[]
 }
 


### PR DESCRIPTION
Changelog
- Updates Option entity to use Token and TokenAmount entities from the Uniswap SDK. Scraps Asset and Quantity entities.
- Updates Option entity with a `setPair` and `pair` function, updates `pair` to `pairAddress`. When option entities are being fetched, the pair will also be fetched and set to the entity.
- Propagates Quantity -> TokenAmount changes throughout codebase (there will definitely be bugs, I fixed most but we will need to test each order type on calls/puts).
- Deletes sdk folder in the root, its out of date and gets in the way when you are trying to import certain files from lib.
- Updates Swap, AddLiquidity, RemoveLiquidity components with Option entity changes
- Adds an optional parameter `assetAddress` to the updateOptions hook, so on mainnet, we can pass in the token addresses! Without checking for token addresses in the options hook, the interface can be tricked into displaying any options with matching underlying token metadata...

Fixes #297 #296  