### PR TITLE
Bug fixes and improved trade warnings

### DIFF
--- a/app/src/components/Market/MarketHeader/MarketHeader.tsx
+++ b/app/src/components/Market/MarketHeader/MarketHeader.tsx
@@ -8,7 +8,6 @@ import Tooltip from '@/components/Tooltip'
 import Spacer from '@/components/Spacer'
 import Loader from '@/components/Loader'
 import LaunchIcon from '@material-ui/icons/Launch'
-import WarningIcon from '@material-ui/icons/Warning'
 
 import useSWR from 'swr'
 import { useOptions } from '@/state/options/hooks'
@@ -154,11 +153,10 @@ const MarketHeader: React.FC<MarketHeaderProps> = ({ marketId, isCall }) => {
                       justifyContent="flex-start"
                       alignItems="center"
                     >
-                      <WarningIcon style={{ color: 'yellow' }} />
-                      <Spacer size="sm" />
+                      <div style={{ minWidth: '.2em' }} />
                       <h4>
                         <Tooltip text={`Choose an option and add liquidity!`}>
-                          N/A
+                          None
                         </Tooltip>
                       </h4>
                     </StyledL>

--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -183,7 +183,8 @@ const AddLiquidity: React.FC = () => {
     if (
       typeof item.market === 'undefined' ||
       item.market === null ||
-      typeof parsedOptionAmount === 'undefined'
+      typeof parsedOptionAmount === 'undefined' ||
+      BigNumber.from(parseEther(lpTotalSupply)).isZero()
     ) {
       return parsedOptionAmount || '0'
     }
@@ -318,9 +319,10 @@ const AddLiquidity: React.FC = () => {
   }
 
   const noLiquidityTitle = {
-    text: 'This pair has no liquidity.',
+    text:
+      'This pair has no liquidity, adding liquidity will initialize this market and set an initial token ratio',
     tip:
-      'Providing liquidity to this pair will set the ratio between the tokens.',
+      'Providing liquidity to this pair will set the ratio between the tokens',
   }
 
   return (
@@ -396,11 +398,7 @@ const AddLiquidity: React.FC = () => {
         </StyledTabs>
       ) : (
         <>
-          <StyledSubtitle>
-            <Tooltip text={noLiquidityTitle.tip}>
-              {noLiquidityTitle.text}
-            </Tooltip>
-          </StyledSubtitle>
+          <StyledSubtitle>{noLiquidityTitle.text}</StyledSubtitle>
           <Spacer size="sm" />
           <PriceInput
             name="primary"
@@ -507,6 +505,7 @@ const AddLiquidity: React.FC = () => {
       ) : (
         <></>
       )}
+      <Spacer size="sm" />
       <Box row justifyContent="flex-start">
         {loading ? (
           <div style={{ width: '100%' }}>
@@ -588,11 +587,20 @@ const StyledTitle = styled.h5`
   font-weight: 700;
   margin: ${(props) => props.theme.spacing[2]}px;
 `
-const StyledSubtitle = styled.h5`
-  color: ${(props) => props.theme.color.white};
-  font-size: 16px;
-  font-weight: 500;
+const StyledSubtitle = styled.div`
+  color: yellow;
+  display: table;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 13px;
+  opacity: 1;
   margin: ${(props) => props.theme.spacing[2]}px;
+  margin-left: -0em !important;
 `
 
 export default AddLiquidity

--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -418,7 +418,7 @@ const AddLiquidity: React.FC = () => {
         </>
       )}
 
-      <Spacer />
+      <Spacer size="sm" />
       <LineItem
         label="LP for"
         data={formatEther(calculateOptionsAddedAsLiquidity())}
@@ -500,7 +500,6 @@ const AddLiquidity: React.FC = () => {
             This amount of underlying tokens is above our guardrail cap of
             $150,000
           </WarningLabel>
-          <Spacer size="sm" />
         </>
       ) : (
         <></>

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -89,6 +89,8 @@ const Swap: React.FC = () => {
   useEffect(() => {
     if (lpPair) {
       setHasL(lpPair.reserveOf(entity.redeem).numerator[2])
+    } else {
+      swapLoaded()
     }
   }, [setHasL, lpPair])
 
@@ -308,11 +310,8 @@ const Swap: React.FC = () => {
         </StyledTitle>
       </Box>
       <Box column alignItems="center">
-        <Spacer size="sm" />
         {hasLiquidity ? null : (
           <WarningTooltip>
-            <WarningIcon />
-            <Spacer size="sm" />
             <h5>There is no liquidity in this option market</h5>
           </WarningTooltip>
         )}
@@ -341,7 +340,7 @@ const Swap: React.FC = () => {
             )}
           </>
         ) : (
-          <Loader />
+          <>{hasLiquidity ? <Loader /> : null}</>
         )}
 
         <Spacer size="sm" />
@@ -355,8 +354,11 @@ const Swap: React.FC = () => {
           valid={parseEther(underlyingTokenBalance).gt(parseEther(cost.debit))}
         />
         <Spacer size="sm" />
-        {inputLoading ? (
-          <Loader />
+        {inputLoading && hasLiquidity ? (
+          <>
+            <Loader />
+            <Spacer />
+          </>
         ) : (
           <LineItem label="Slippage" data={`${impact}`} units="%" />
         )}
@@ -473,15 +475,14 @@ const Swap: React.FC = () => {
               </PurchaseInfo>
             ) : (
               <>
-                <Spacer />
                 {error ? (
-                  <StyledError>Order quantity too large!</StyledError>
+                  <WarningLabel>Order quantity too large!</WarningLabel>
                 ) : null}
               </>
             )}
           </StyledSummary>
         ) : null}
-        <Spacer />
+        <Spacer size="sm" />
         {isAboveGuardCap() ? (
           <>
             <div style={{ marginTop: '-.5em' }} />
@@ -559,7 +560,8 @@ const Swap: React.FC = () => {
                   !parsedAmount?.gt(0) ||
                   loading ||
                   isAboveGuardCap() ||
-                  error
+                  error ||
+                  hasLiquidity
                 }
                 full
                 size="sm"
@@ -585,7 +587,16 @@ const WarningTooltip = styled.div`
   color: yellow;
   font-size: 18px;
   display: flex;
+  display: table;
   align-items: center;
+  justify-content: center;
+  width: 100%;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 14px;
+  opacity: 1;
 `
 const StyledTitle = styled.h5`
   color: ${(props) => props.theme.color.white};
@@ -598,12 +609,7 @@ const PurchaseInfo = styled.span`
   color: ${(props) => props.theme.color.grey[400]};
   margin-top: 1em;
 `
-const StyledError = styled.span`
-  color: ${(props) => props.theme.color.red[500]};
-  font-size: 18px;
-  margin-bottom: -0.3em;
-  font-weight: 600;
-`
+
 const StyledData = styled.span`
   color: ${(props) => props.theme.color.white};
   font-size: 16px;

--- a/app/src/components/TopBar/TopBar.tsx
+++ b/app/src/components/TopBar/TopBar.tsx
@@ -45,9 +45,7 @@ const TopBar: React.FC = () => {
         <StyledNav isMain={chainId !== 1}>
           <Link href="/markets">
             <StyledNavItem
-              active={
-                location.pathname.indexOf('/markets') !== -1 ? true : false
-              }
+              active={location.pathname === '/markets' ? true : false}
             >
               Markets
             </StyledNavItem>

--- a/app/src/components/WarningLabel/WarningLabel.tsx
+++ b/app/src/components/WarningLabel/WarningLabel.tsx
@@ -2,19 +2,23 @@ import React from 'react'
 import styled from 'styled-components'
 
 const WarningLabel: React.FC = ({ children }) => (
-  <StyledWarningLabel>{children}</StyledWarningLabel>
+  <StyledWarningLabel>
+    <p>{children}</p>
+  </StyledWarningLabel>
 )
 
 const StyledWarningLabel = styled.div`
   color: ${(props) => props.theme.color.red[500]};
-  display: flex;
-  font-size: 14px;
-  justify-content: center;
+  display: table;
   align-items: center;
+  justify-content: center;
+  width: 100%;
   letter-spacing: 1px;
   text-transform: uppercase;
-  opacity: 0.66;
-  width: 100%;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 14px;
+  opacity: 1;
 `
 
 export default WarningLabel

--- a/app/src/hooks/transactions/useGuardCap.ts
+++ b/app/src/hooks/transactions/useGuardCap.ts
@@ -15,10 +15,14 @@ const useGuardCap = (asset: string, orderType: Operation): BigNumber => {
   const [cap, setCap] = useState('0.00')
 
   const getMarketDetails = () => {
+    let assetName = asset.toLowerCase()
+    if (assetName === 'weth') {
+      assetName = 'eth'
+    }
     const symbol: string = asset
-    const name: string = NAME_FOR_MARKET[asset.toLowerCase()]
-    const key: string = COINGECKO_ID_FOR_MARKET[asset.toLowerCase()]
-    const address: string = ADDRESS_FOR_MARKET[asset.toLowerCase()]
+    const name: string = NAME_FOR_MARKET[assetName]
+    const key: string = COINGECKO_ID_FOR_MARKET[assetName]
+    const address: string = ADDRESS_FOR_MARKET[assetName]
     return { name, symbol, key, address }
   }
   const { name, symbol, key, address } = getMarketDetails()


### PR DESCRIPTION
Closes #328 
Closes #308 

Changelog:
- improved warnings in swap and add liquidity
- improved warning component
- changed header styling
- removed Markets highlight unless on market selection page (functions as a back to market button when on a selected market)