### PR TITLE
fix(hasLiquidity): Adds hasLiquidity attribute to market. Fixes all o…

### DIFF
--- a/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -83,7 +83,7 @@ const AddLiquidity: React.FC = () => {
   // has liquidity?
   useEffect(() => {
     if (item.market) {
-      setHasL(item.market.reserveOf(entity.redeem).numerator[2])
+      setHasL(item.market.hasLiquidity)
     }
   }, [setHasL, item])
 
@@ -275,7 +275,12 @@ const AddLiquidity: React.FC = () => {
       parsedOptionAmount !== undefined
     ) {
       // if the reserves will be set based on the inputs
-      const inputShort = parsedOptionAmount // pair has short tokens, so need to convert our desired options to short options))
+      let inputShort
+      if (orderType === Operation.ADD_LIQUIDITY) {
+        inputShort = entity.proportionalShort(parsedOptionAmount)
+      } else {
+        inputShort = parsedOptionAmount // pair has short tokens, so need to convert our desired options to short options))
+      }
       const path = [entity.redeem.address, entity.underlying.address]
       const quote = Trade.getSpotPremium(
         entity.baseValue.raw.toString(),

--- a/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
+++ b/app/src/components/Market/OrderCard/components/OrderOptions/OrderOptions.tsx
@@ -40,10 +40,6 @@ const LPOptions: React.FC<{ balance?: any; open?: boolean }> = ({
       updateItem(item, t)
     }
   }
-  const reserve0Units =
-    item.market.token0.address === item.entity.underlying.address
-      ? item.asset.toUpperCase()
-      : 'SHORT'
   return (
     <>
       <Box row alignItems="center" justifyContent="space-between">

--- a/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/app/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -130,7 +130,7 @@ const RemoveLiquidity: React.FC = () => {
   const calculateToken0PerToken1 = useCallback(() => {
     if (
       typeof item.market === 'undefined' ||
-      typeof item.market.reserve0.numerator[2] === 'undefined' ||
+      !item.market.hasLiquidity ||
       item.market === null
     )
       return '0'
@@ -141,7 +141,7 @@ const RemoveLiquidity: React.FC = () => {
   const calculateToken1PerToken0 = useCallback(() => {
     if (
       typeof item.market === 'undefined' ||
-      typeof item.market.reserve0.numerator[2] === 'undefined' ||
+      !item.market.hasLiquidity ||
       item.market === null
     )
       return '0'
@@ -153,7 +153,7 @@ const RemoveLiquidity: React.FC = () => {
     if (
       typeof item.market === 'undefined' ||
       item.market === null ||
-      typeof item.market.reserve0.numerator[2] === 'undefined'
+      !item.market.hasLiquidity
     )
       return '0'
     const poolShare = BigNumber.from(parseEther(lpTotalSupply)).gt(0)
@@ -168,7 +168,7 @@ const RemoveLiquidity: React.FC = () => {
     if (
       typeof item.market === 'undefined' ||
       item.market === null ||
-      typeof item.market.reserve0.numerator[2] === 'undefined' ||
+      !item.market.hasLiquidity ||
       BigNumber.from(parseEther(lpTotalSupply)).isZero()
     )
       return {
@@ -200,7 +200,7 @@ const RemoveLiquidity: React.FC = () => {
     if (
       typeof item.market === 'undefined' ||
       item.market === null ||
-      typeof item.market.reserve0.numerator[2] === 'undefined' ||
+      !item.market.hasLiquidity ||
       BigNumber.from(parseEther(lpTotalSupply)).isZero()
     )
       return '0'
@@ -238,7 +238,7 @@ const RemoveLiquidity: React.FC = () => {
     if (
       typeof item.market === 'undefined' ||
       item.market === null ||
-      typeof item.market.reserve0.numerator[2] === 'undefined' ||
+      !item.market.hasLiquidity ||
       BigNumber.from(parseEther(lpTotalSupply)).isZero() ||
       ratio === 0
     ) {
@@ -276,7 +276,7 @@ const RemoveLiquidity: React.FC = () => {
     if (
       typeof item.market === 'undefined' ||
       item.market === null ||
-      typeof item.market.reserve0.numerator[2] === 'undefined' ||
+      !item.market.hasLiquidity ||
       BigNumber.from(parseEther(lpTotalSupply)).isZero()
     )
       return '0'
@@ -300,10 +300,7 @@ const RemoveLiquidity: React.FC = () => {
   }, [item.market, lp, lpTotalSupply, ratio, item])
 
   const calculateBurn = useCallback(() => {
-    if (
-      typeof item.market === 'undefined' ||
-      typeof item.market.reserve0.numerator[2] === 'undefined'
-    )
+    if (typeof item.market === 'undefined' || !item.market.hasLiquidity)
       return '0'
     const liquidity = parseEther(lp)
       .mul(parseEther(ratio.toString()))

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -84,15 +84,14 @@ const Swap: React.FC = () => {
   const price = usePrice()
   // pair and option entities
   const entity = item.entity
-  const lpPair = useReserves(entity.underlying, entity.redeem).data
   // has liquidity?
   useEffect(() => {
-    if (lpPair) {
-      setHasL(lpPair.reserveOf(entity.redeem).numerator[2])
+    if (item.market) {
+      setHasL(item.market.hasLiquidity)
     } else {
       swapLoaded()
     }
-  }, [setHasL, lpPair])
+  }, [setHasL, item.market])
 
   let title = { text: '', tip: '' }
   let tokenAddress: string
@@ -183,8 +182,6 @@ const Swap: React.FC = () => {
       let credit = '0'
       let short = '0'
       const size = parsedAmount
-      const base = entity.baseValue.raw.toString()
-      const quote = entity.quoteValue.raw.toString()
       let actualPremium: TokenAmount
       let spot: TokenAmount
       let slippage
@@ -263,10 +260,10 @@ const Swap: React.FC = () => {
       swapLoaded()
       setCost({ debit, credit, short })
     }
-    if (lpPair && inputLoading) {
+    if (item.market && inputLoading) {
       calculateTotalCost()
     }
-  }, [item, parsedAmount, inputLoading, lpPair])
+  }, [item, parsedAmount, inputLoading, item.market])
 
   const calculateProportionalShort = useCallback(() => {
     const sizeWei = parsedAmount
@@ -560,7 +557,7 @@ const Swap: React.FC = () => {
                   loading ||
                   isAboveGuardCap() ||
                   error ||
-                  hasLiquidity
+                  !hasLiquidity
                 }
                 full
                 size="sm"

--- a/app/src/lib/entities/market.ts
+++ b/app/src/lib/entities/market.ts
@@ -283,4 +283,9 @@ export class Market extends Pair {
 
     return [shortValue, underlyingValue, totalUnderlyingValue]
   }
+  public get hasLiquidity(): boolean {
+    const reserve0Liquidity: boolean = this.reserve0.greaterThan('0')
+    const reserve1Liquidity: boolean = this.reserve1.greaterThan('0')
+    return reserve0Liquidity && reserve1Liquidity
+  }
 }

--- a/app/src/lib/uniswap.ts
+++ b/app/src/lib/uniswap.ts
@@ -104,7 +104,9 @@ export class Uniswap {
         methodName = 'mintOptionsThenFlashCloseLong'
         args = [
           trade.option.address,
-          trade.outputAmount.raw.toString(),
+          trade.option
+            .proportionalLong(trade.outputAmount.raw.toString())
+            .toString(),
           minPayout.toString(),
         ]
         value = '0'
@@ -147,8 +149,7 @@ export class Uniswap {
         const underlyingReserves = trade.market.reserveOf(
           trade.option.underlying
         )
-        const hasLiquidity =
-          redeemReserves.numerator[2] || underlyingReserves.numerator[2]
+        const hasLiquidity = trade.market.hasLiquidity
         const denominator = !hasLiquidity
           ? 0
           : strikeRatio


### PR DESCRIPTION
…rders.

Few things in here that are nice:
- Added `hasLiquidity` getter to the `market.ts` entity. So we can do `item.market.hasLiquidity` to check if the option has liquidity. Much better global check, I propagated most places but might have missed some spots.
- Fixes write order types, a bug in `uniswap.ts` write order type which was passing in the redeemQuantity instead of the proportional long option quantity to the fn.
- Adds a conditional case to Add_Liquidity order types when calculating implied option prices. In the case the option market has no liquidity, the inputs are long option/underlying. In the case that tokens are being directly added to the pair, the inputs are short option tokens and underlying. The case handles the difference in inputs by also passing the short option token proportional amount or input to the implied option pricing fn.
- Fixes #334 #335 