### PR TITLE
Fix/premium calculations

### DIFF
--- a/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
+++ b/app/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
@@ -16,6 +16,8 @@ import { useItem } from '@/state/order/hooks'
 import GreeksTableRow, { Greeks } from '../GreeksTableRow'
 
 import numeral from 'numeral'
+import isZero from '@/utils/isZero'
+import { parseEther } from 'ethers/lib/utils'
 
 export interface TableColumns {
   key: string
@@ -91,7 +93,7 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
           </span>
         </TableCell>
         <TableCell>
-          {premium !== '0.00' ? (
+          {!isZero(parseEther(premium)) ? (
             <span>
               {numeral(breakeven).format('0.00a')} <Units>DAI</Units>
             </span>
@@ -99,7 +101,7 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
             <>{`-`}</>
           )}
         </TableCell>
-        {premium !== '0.00' ? (
+        {!isZero(parseEther(premium)) ? (
           <TableCell>
             {isCall ? (
               <StyledR>

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -88,6 +88,7 @@ const Swap: React.FC = () => {
   useEffect(() => {
     if (item.market) {
       setHasL(item.market.hasLiquidity)
+      console.log(item.market.hasLiquidity)
     } else {
       swapLoaded()
     }

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -64,7 +64,7 @@ const Swap: React.FC = () => {
       ? formatEther(item.market.spotClosePremium.raw.toString())
       : orderType === Operation.SHORT
       ? formatEther(item.market.spotUnderlyingToShort.raw.toString())
-      : formatEther(item.market.spotShortToUnderlying.raw.toString())
+      : formatEther(item.market.spotUnderlyingToShort.raw.toString())
   )
   const [impact, setImpact] = useState('0.00')
   const [error, setError] = useState(false)
@@ -244,13 +244,13 @@ const Swap: React.FC = () => {
             )
             setImpact(slippage)
             setPrem(
-              formatEther(item.market.spotShortToUnderlying.raw.toString())
+              formatEther(item.market.spotUnderlyingToShort.raw.toString())
             )
             short = formatEther(actualPremium.raw.toString())
           } else {
             setImpact('0.00')
             setPrem(
-              formatEther(item.market.spotShortToUnderlying.raw.toString())
+              formatEther(item.market.spotUnderlyingToShort.raw.toString())
             )
           }
         }

--- a/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/app/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -196,6 +196,7 @@ const Swap: React.FC = () => {
             setImpact(slippage)
             setPrem(formatEther(spot.raw.toString()))
             debit = formatEther(actualPremium.raw.toString())
+            console.log(spot.raw.toString(), actualPremium.raw.toString())
           } else {
             setImpact('0.00')
             setPrem(formatEther(item.market.spotOpenPremium.raw.toString()))

--- a/app/src/lib/entities/market.ts
+++ b/app/src/lib/entities/market.ts
@@ -60,9 +60,7 @@ export class Market extends Pair {
    */
   public getOpenPremium = (outputAmount: TokenAmount): TokenAmount => {
     if (
-      typeof this.reserveOf(this.option.redeem).numerator[2] === 'undefined' ||
-      typeof this.reserveOf(this.option.underlying).numerator[2] ===
-        'undefined' ||
+      !this.hasLiquidity ||
       this.reserveOf(outputAmount.token).greaterThan(outputAmount.raw)
     ) {
       return new TokenAmount(this.option.underlying, '0')
@@ -102,7 +100,10 @@ export class Market extends Pair {
    * @param outputAmount The quantity of shortOptionTokens per optionToken that needs to be closed.
    */
   public getClosePremium = (outputAmount: TokenAmount): TokenAmount => {
-    if (!this.reserveOf(this.option.redeem).numerator[2]) {
+    if (
+      !this.hasLiquidity ||
+      this.reserveOf(outputAmount.token).greaterThan(outputAmount.raw)
+    ) {
       return new TokenAmount(this.option.underlying, '0')
     }
     const underlyingsMinted = this.option.proportionalLong(
@@ -135,7 +136,7 @@ export class Market extends Pair {
    * @param inputAmount Quantity of shortOptionTokens to purchase.
    */
   public getShortPremium = (inputAmount: TokenAmount): TokenAmount => {
-    if (!this.reserveOf(this.option.redeem).numerator[2]) {
+    if (!this.hasLiquidity) {
       return new TokenAmount(this.option.underlying, '0')
     }
 

--- a/app/src/lib/entities/option.ts
+++ b/app/src/lib/entities/option.ts
@@ -1,7 +1,7 @@
 import ethers, { BigNumberish, BigNumber } from 'ethers'
 import OptionArtifact from '@primitivefi/contracts/artifacts/Option.json'
 import { formatEther, parseEther } from 'ethers/lib/utils'
-import { Pair, Token, TokenAmount } from '@uniswap/sdk'
+import { ChainId, Pair, Token, TokenAmount } from '@uniswap/sdk'
 import { STABLECOINS, ADDRESS_ZERO } from '@/constants/index'
 import isZero from '@/utils/isZero'
 
@@ -153,8 +153,13 @@ export class Option extends Token {
     let isCall = false
     if (+formatEther(baseValue) === 1) {
       if (+formatEther(quoteValue) === 1) {
-        const quoteToken = this.underlying.symbol
-        if (quoteToken === STABLECOINS[this.chainId].symbol) {
+        if (this.isMainnet) {
+          if (this.strike.address === STABLECOINS[this.chainId].address) {
+            isCall = true
+          }
+        }
+        const quoteToken = this.strike.symbol
+        if (quoteToken.toUpperCase() === STABLECOINS[this.chainId].symbol) {
           isCall = true
         }
       } else {
@@ -170,6 +175,11 @@ export class Option extends Token {
     let isPut = false
     if (+formatEther(quoteValue) === 1) {
       if (+formatEther(baseValue) === 1) {
+        if (this.isMainnet) {
+          if (this.underlying.address === STABLECOINS[this.chainId].address) {
+            isPut = true
+          }
+        }
         const baseToken = this.strike.symbol
         if (baseToken === STABLECOINS[this.chainId].symbol) {
           isPut = true
@@ -179,6 +189,10 @@ export class Option extends Token {
       }
     }
     return isPut
+  }
+
+  public get isMainnet(): boolean {
+    return this.chainId === ChainId.MAINNET
   }
 
   public getTimeToExpiry(): number {


### PR DESCRIPTION
Fixes
- #337 By propagating `hasLiquidity` getter to necessary checks for liquidity.
- #339 By using the shortToUnderlying premium.
- #341 Through the 337 fix.

Adds
- isZero checks to the premium in `OptionsTableRow`
- Mainnet conditional statement that compares mainnet dai address to check if option is put or call.