### PR TITLE
Feature/consolidate

### DIFF
--- a/src/components/CardHeader/CardHeader.tsx
+++ b/src/components/CardHeader/CardHeader.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+import Title from '@/components/Title'
+import Tooltip from '@/components/Tooltip'
+import ClearIcon from '@material-ui/icons/Clear'
+import Button from '@/components/Button'
+
+interface TitleType {
+  tip: string
+  text: string
+}
+
+interface CardHeaderProps {
+  title: TitleType
+  onClick?: () => void
+}
+
+const CardHeader: React.FC<CardHeaderProps> = ({ title, onClick }) => {
+  return (
+    <Title full>
+      <Tooltip text={title.tip}>{title.text}</Tooltip>
+      {onClick ? (
+        <CustomButton>
+          <Button variant="transparent" size="sm" onClick={onClick}>
+            <ClearIcon />
+          </Button>
+        </CustomButton>
+      ) : null}
+    </Title>
+  )
+}
+
+const CustomButton = styled.div`
+  margin-top: -0.1em;
+  background: none;
+`
+
+export default CardHeader

--- a/src/components/CardHeader/index.ts
+++ b/src/components/CardHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CardHeader'

--- a/src/components/Description/Description.tsx
+++ b/src/components/Description/Description.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useCallback, useEffect } from 'react'
+import styled from 'styled-components'
+import Box from '@/components/Box'
+
+const Description: React.FC = ({ children }) => {
+  return (
+    <StyledSummary column alignItems="flex-start">
+      <PurchaseInfo>
+        <StyledSpan>{children}</StyledSpan>
+      </PurchaseInfo>
+    </StyledSummary>
+  )
+}
+
+const StyledSpan = styled.span`
+  color: ${(props) => props.theme.color.grey[400]};
+`
+
+const StyledSummary = styled(Box)`
+  display: flex;
+  flex: 1;
+  min-width: 100%;
+  margin-bottom: ${(props) => props.theme.spacing[3]}px;
+`
+
+const PurchaseInfo = styled.div`
+  color: ${(props) => props.theme.color.grey[400]};
+  vertical-align: middle;
+  display: table;
+  margin-bottom: -1em;
+`
+
+export default Description

--- a/src/components/Description/index.ts
+++ b/src/components/Description/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Description'

--- a/src/components/Liquidity/LiquidityTable.tsx
+++ b/src/components/Liquidity/LiquidityTable.tsx
@@ -9,9 +9,19 @@ import { TableColumns } from './LiquidityTable/LiquidityTableRow'
 
 import LiquidityTableHeader from './LiquidityTable/LiquidityTableHeader'
 import LiquidityTableRow from './LiquidityTable/LiquidityTableRow'
+import LoadingTable from '@/components/Market/OptionsTable/LoadingTable'
+
+import { usePositions } from '@/state/positions/hooks'
+import { useItem, useUpdateItem } from '@/state/order/hooks'
+import { useOptions, useUpdateOptions } from '@/state/options/hooks'
+import { formatEther } from 'ethers/lib/utils'
+import { Operation } from '@primitivefi/sdk'
 
 const LiquidityTable: React.FC = (props) => {
-  const tableColumns: TableColumns = {
+  const positions = usePositions()
+  const updateItem = useUpdateItem()
+  const options = useOptions()
+  /* const tableColumns: TableColumns = {
     key: 'key',
     asset: 'tableAssset',
     strike: '0.00',
@@ -22,14 +32,75 @@ const LiquidityTable: React.FC = (props) => {
     liquidity: ['0.00', '0.00'],
     expiry: 0,
     isCall: true,
-  }
+  } */
+
+  const formatTableColumns = useCallback(
+    (option: any): TableColumns => {
+      const tableKey: string = option.entity.address
+      /* const tableAssset: string = asset.toUpperCase() */
+      const tableStrike: string = option.entity.strikePrice.toString()
+      const tableBid: string = formatEther(
+        option.market.spotClosePremium.raw.toString()
+      ).toString()
+      const tableAsk: string = formatEther(
+        option.market.spotOpenPremium.raw.toString()
+      ).toString()
+
+      const tableReserve0: string = formatEther(
+        option.market.reserveOf(option.entity.underlying).raw.toString()
+      ).toString()
+      const tableReserve1: string = formatEther(
+        option.market.reserveOf(option.entity.redeem).raw.toString()
+      ).toString()
+
+      // tableReserve1 should always be short option token
+      const tableReserves: string[] = [tableReserve0, tableReserve1]
+      const tableExpiry: number = option.entity.expiryValue
+
+      const tableColumns: TableColumns = {
+        key: tableKey,
+        asset: option.entity.underlying.symbol,
+        strike: '0.00',
+        share: '0.00',
+        asset1: tableReserve0,
+        asset2: tableReserve1,
+        fees: '0.00',
+        liquidity: tableReserves,
+        expiry: tableExpiry,
+        isCall: option.entity.isCall,
+      }
+      return tableColumns
+    },
+    [positions]
+  )
   return (
     <OptionsContainer>
       <Table>
         <LiquidityTableHeader />
         <LiquidityTableContainer>
           <LiquidityTableContent>
-            <LiquidityTableRow
+            {positions.loading ? (
+              <LoadingTable />
+            ) : (
+              <ScrollBody>
+                {positions.options.map((option) => {
+                  const tableColumns: TableColumns = formatTableColumns(
+                    option.attributes
+                  )
+                  return (
+                    <LiquidityTableRow
+                      key={'test'}
+                      onClick={() =>
+                        updateItem(option.attributes, Operation.ADD_LIQUIDITY)
+                      }
+                      href={`/liquidity`}
+                      columns={tableColumns}
+                    />
+                  )
+                })}
+              </ScrollBody>
+            )}
+            {/* <LiquidityTableRow
               key={'test'}
               onClick={() => {}}
               href={`/liquidity`}
@@ -40,7 +111,7 @@ const LiquidityTable: React.FC = (props) => {
               onClick={() => {}}
               href={`/liquidity`}
               columns={tableColumns}
-            />
+            /> */}
           </LiquidityTableContent>
         </LiquidityTableContainer>
       </Table>

--- a/src/components/Liquidity/LiquidityTable.tsx
+++ b/src/components/Liquidity/LiquidityTable.tsx
@@ -19,10 +19,16 @@ import { BigNumber } from 'ethers'
 import { Operation } from '@primitivefi/sdk'
 import { Fraction, TokenAmount } from '@uniswap/sdk'
 
-const LiquidityTable: React.FC = (props) => {
+export interface OptionsTableProps {
+  callActive: boolean
+}
+
+const LiquidityTable: React.FC<OptionsTableProps> = (props) => {
+  const { callActive } = props
   const positions = usePositions()
   const updateItem = useUpdateItem()
   const options = useOptions()
+  const type = callActive ? 'calls' : 'puts'
   /* const tableColumns: TableColumns = {
     key: 'key',
     asset: 'tableAssset',
@@ -100,7 +106,7 @@ const LiquidityTable: React.FC = (props) => {
               <LoadingTable />
             ) : (
               <ScrollBody>
-                {options.calls.map((option) => {
+                {options[type].map((option) => {
                   const tableColumns: TableColumns = formatTableColumns(option)
                   const hasPosition =
                     positions.options
@@ -131,18 +137,6 @@ const LiquidityTable: React.FC = (props) => {
                 })}
               </ScrollBody>
             )}
-            {/* <LiquidityTableRow
-              key={'test'}
-              onClick={() => {}}
-              href={`/liquidity`}
-              columns={tableColumns}
-            />
-            <LiquidityTableRow
-              key={'test'}
-              onClick={() => {}}
-              href={`/liquidity`}
-              columns={tableColumns}
-            /> */}
           </LiquidityTableContent>
         </LiquidityTableContainer>
       </Table>

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableHeader/LiquidityTableHeader.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableHeader/LiquidityTableHeader.tsx
@@ -18,24 +18,30 @@ export const headers = [
     tip: 'The purchase price for the underlying asset of this option.',
   },
   {
+    name: 'Price',
+    tip: 'The ask price of 1 option token.',
+  },
+  {
     name: 'Share',
-    tip:
-      'The price the underlying asset must reach to reach a net cost of zero.',
+    tip: 'The proportion of ownership of the option pair.',
   },
   {
-    name: 'Asset 1',
-    tip:
-      'The current spot price of an option token willing to be purchased at.',
+    name: 'Pool Size',
+    tip: 'The amount of underlying tokens in the pool.',
   },
   {
-    name: 'Asset 2',
-    tip: 'The current spot price of an option token willing to be sold at.',
+    name: 'Balance 1',
+    tip: 'Your balance of token 1 in the option pair.',
   },
   {
-    name: 'Fees',
-    tip: 'The profit or loss of the position.',
+    name: 'Balance 2',
+    tip: 'Your balance of token 2 in the option pair.',
   },
-  { name: 'Liquidity', tip: 'The quantity of tokens in the pool.' },
+  {
+    name: 'Total Assets',
+    tip: 'Your total balance of underlying tokens in the option pair.',
+  },
+
   { name: 'Expiry', tip: 'The maturity date of the option token.' },
   { name: '', tip: null },
 ]

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableHeader/LiquidityTableHeader.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableHeader/LiquidityTableHeader.tsx
@@ -30,18 +30,9 @@ export const headers = [
     tip: 'The amount of underlying tokens in the pool.',
   },
   {
-    name: 'Balance 1',
-    tip: 'Your balance of token 1 in the option pair.',
+    name: 'Pool Ratio',
+    tip: 'The ratio of underlying tokens to short option tokens.',
   },
-  {
-    name: 'Balance 2',
-    tip: 'Your balance of token 2 in the option pair.',
-  },
-  {
-    name: 'Total Assets',
-    tip: 'Your total balance of underlying tokens in the option pair.',
-  },
-
   { name: 'Expiry', tip: 'The maturity date of the option token.' },
   { name: '', tip: null },
 ]
@@ -56,7 +47,11 @@ const LiquidityTableHeader: React.FC = () => {
               if (index === headers.length - 1) {
                 return (
                   <>
-                    <TableCell></TableCell>
+                    <TableCell>
+                      <StyledButtonCell key={'Open'}>
+                        <Spacer />
+                      </StyledButtonCell>
+                    </TableCell>
                   </>
                 )
               }

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -9,17 +9,12 @@ import { parseEther } from 'ethers/lib/utils'
 import formatExpiry from '@/utils/formatExpiry'
 import { useItem, useUpdateItem } from '@/state/order/hooks'
 import Button from '@/components/Button'
-import { useClickAway } from '@/hooks/utils/useClickAway'
-import AddIcon from '@material-ui/icons/Add'
-import CheckIcon from '@material-ui/icons/Check'
-import PriceInput from '@/components/PriceInput'
-import ClearIcon from '@material-ui/icons/Clear'
-import Tooltip from '@/components/Tooltip'
 import Box from '@/components/Box'
-import Spacer from '@/components/Spacer'
 import Switch from '@/components/Switch'
 
 import { AddLiquidity } from '@/components/Market/OrderCard/components/AddLiquidity'
+import { RemoveLiquidity } from '@/components/Market/OrderCard/components/RemoveLiquidity'
+import { Operation } from '@primitivefi/sdk'
 
 export interface TableColumns {
   key: string
@@ -45,8 +40,18 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   columns,
   href,
 }) => {
+  const [provide, setProvide] = useState(true)
   const [toggle, setToggle] = useState(false)
   const { item } = useItem()
+  const updateItem = useUpdateItem()
+
+  useEffect(() => {
+    if (provide) {
+      updateItem(item, Operation.ADD_LIQUIDITY, item.market)
+    } else {
+      updateItem(item, Operation.REMOVE_LIQUIDITY_CLOSE, item.market)
+    }
+  }, [provide, item, updateItem])
 
   const currentTimestamp = new Date()
   const {
@@ -62,7 +67,8 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
     isCall,
   } = columns
   const handleOnClick = useCallback(() => {
-    onClick()
+    //setProvide(true)
+    //onClick()
     setToggle(!toggle)
   }, [toggle, setToggle, item])
   const handleOnAdd = (e) => {
@@ -184,7 +190,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         </StyledButtonCell>
       </TableRow>
       {toggle && item.entity ? (
-        <OrderTableRow onClick={handleOnAdd} id="order-row">
+        <OrderTableRow onClick={() => {}} id="order-row">
           <OrderContainer>
             {/* <Spacer />
             <StyledTitle>
@@ -227,12 +233,12 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
             /> */}
 
             <Switch
-              active={true}
-              onClick={() => {}}
+              active={provide}
+              onClick={() => setProvide(!provide)}
               primaryText="Add"
               secondaryText="Remove"
             />
-            <AddLiquidity />
+            {provide ? <AddLiquidity /> : <RemoveLiquidity />}
           </OrderContainer>
         </OrderTableRow>
       ) : (

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -224,35 +224,12 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
           <TableCell>
             <span>
               {numeral(
-                formatEther(calculateLiquidityValuePerShare().underlyingPerLp)
-              ).format('(0.00a)')}{' '}
-              <Units>{assetSymbols().asset1Symbol}</Units>
-            </span>
-          </TableCell>
-        ) : (
-          <TableCell>-</TableCell>
-        )}
-        {!isZero(parseEther(asset2)) ? (
-          <TableCell>
-            <span>
-              {numeral(
-                formatEther(calculateLiquidityValuePerShare().shortPerLp)
-              ).format('(0.00a)')}{' '}
-              <Units>{assetSymbols().asset2Symbol}</Units>
-            </span>
-          </TableCell>
-        ) : (
-          <TableCell>-</TableCell>
-        )}
-        {!isZero(parseEther(asset2)) && !isZero(parseEther(asset1)) ? (
-          <TableCell>
-            <span>
-              {numeral(
                 formatEther(
-                  calculateLiquidityValuePerShare().totalUnderlyingPerLp
+                  entity.proportionalShort(
+                    market.spotUnderlyingToShort.raw.toString()
+                  )
                 )
-              ).format('(0.00a)')}{' '}
-              <Units>{assetSymbols().asset1Symbol}</Units>
+              ).format('(0.00)')}{' '}
             </span>
           </TableCell>
         ) : (
@@ -266,7 +243,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         ) : (
           <TableCell>-</TableCell>
         )}
-        <StyledButtonCell key={'Open'}>
+        <TableCell key={'Open'}>
           <Button
             onClick={handleOnClick}
             variant={
@@ -279,51 +256,11 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
             size="sm"
             text="Add Liquidity"
           />
-        </StyledButtonCell>
+        </TableCell>
       </TableRow>
       {toggle && item.entity ? (
         <OrderTableRow onClick={() => {}} id="order-row">
           <OrderContainer>
-            {/* <Spacer />
-            <StyledTitle>
-              <Tooltip text={'Manage tokens in the pool.'}>
-                {'Pool Liquidity'}
-              </Tooltip>
-              <CustomButton>
-                <Button variant="transparent" size="sm" onClick={handleOnClick}>
-                  <ClearIcon />
-                </Button>
-              </CustomButton>
-            </StyledTitle>
-            <Separator />
-            <Spacer />
-
-            <Switch
-              active={true}
-              onClick={() => {}}
-              primaryText="Add"
-              secondaryText="Remove"
-            />
-
-            <Spacer />
-            <PriceInput
-              title="Quantity"
-              name="primary"
-              onChange={() => {}}
-              quantity={'1'}
-              onClick={() => {}}
-              valid={true}
-            />
-            <Spacer />
-            <Button
-              disabled={false}
-              full
-              size="sm"
-              onClick={() => {}}
-              isLoading={false}
-              text={'Confirm'}
-            /> */}
-
             <Switch
               active={provide}
               onClick={() => setProvide(!provide)}

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -45,13 +45,13 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   const { item } = useItem()
   const updateItem = useUpdateItem()
 
-  useEffect(() => {
-    if (provide) {
+  /* useEffect(() => {
+    if (provide && item) {
       updateItem(item, Operation.ADD_LIQUIDITY, item.market)
-    } else {
+    } else if (item) {
       updateItem(item, Operation.REMOVE_LIQUIDITY_CLOSE, item.market)
     }
-  }, [provide, item, updateItem])
+  }, [provide, item, updateItem]) */
 
   const currentTimestamp = new Date()
   const {
@@ -68,7 +68,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   } = columns
   const handleOnClick = useCallback(() => {
     //setProvide(true)
-    //onClick()
+    onClick()
     setToggle(!toggle)
   }, [toggle, setToggle, item])
   const handleOnAdd = (e) => {

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -16,12 +16,12 @@ import { AddLiquidity } from '@/components/Market/OrderCard/components/AddLiquid
 import { RemoveLiquidity } from '@/components/Market/OrderCard/components/RemoveLiquidity'
 
 import { useWeb3React } from '@web3-react/core'
-import { useItem, useUpdateItem } from '@/state/order/hooks'
+import { useItem, useUpdateItem, useRemoveItem } from '@/state/order/hooks'
 import useTokenBalance from '@/hooks/useTokenBalance'
 import useTokenTotalSupply from '@/hooks/useTokenTotalSupply'
 import { useClickAway } from '@/hooks/utils/useClickAway'
 
-import { Option, Market } from '@primitivefi/sdk'
+import { Option, Market, Operation } from '@primitivefi/sdk'
 import { Fraction, TokenAmount } from '@uniswap/sdk'
 
 export interface TableColumns {
@@ -70,6 +70,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   const [toggle, setToggle] = useState(false)
   const { item } = useItem()
   const updateItem = useUpdateItem()
+  const removeItem = useRemoveItem()
   const { account, active, library } = useWeb3React()
   const lpToken = market ? market.liquidityToken.address : ''
   const token0 = market ? market.token0.symbol : ''
@@ -149,6 +150,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   }
   const nodeRef = useClickAway(() => {
     setToggle(false)
+    removeItem()
   })
 
   const units = isCall ? asset.toUpperCase() : 'DAI'

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -7,7 +7,7 @@ import numeral from 'numeral'
 import isZero from '@/utils/isZero'
 import { parseEther } from 'ethers/lib/utils'
 import formatExpiry from '@/utils/formatExpiry'
-import { useItem } from '@/state/order/hooks'
+import { useItem, useUpdateItem } from '@/state/order/hooks'
 import Button from '@/components/Button'
 import { useClickAway } from '@/hooks/utils/useClickAway'
 import AddIcon from '@material-ui/icons/Add'
@@ -17,6 +17,9 @@ import ClearIcon from '@material-ui/icons/Clear'
 import Tooltip from '@/components/Tooltip'
 import Box from '@/components/Box'
 import Spacer from '@/components/Spacer'
+import Switch from '@/components/Switch'
+
+import { AddLiquidity } from '@/components/Market/OrderCard/components/AddLiquidity'
 
 export interface TableColumns {
   key: string
@@ -44,6 +47,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
 }) => {
   const [toggle, setToggle] = useState(false)
   const { item } = useItem()
+
   const currentTimestamp = new Date()
   const {
     key,
@@ -58,8 +62,9 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
     isCall,
   } = columns
   const handleOnClick = useCallback(() => {
+    onClick()
     setToggle(!toggle)
-  }, [toggle, setToggle])
+  }, [toggle, setToggle, item])
   const handleOnAdd = (e) => {
     e.stopPropagation()
     onClick()
@@ -69,6 +74,20 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   }) */
 
   const units = isCall ? asset.toUpperCase() : 'DAI'
+
+  const assetSymbols = useCallback(() => {
+    let asset1Symbol
+    let asset2Symbol
+    if (parseEther(asset1).gt(parseEther(asset2))) {
+      asset1Symbol = 'SHORT'
+      asset2Symbol = units
+    } else {
+      asset1Symbol = units
+      asset2Symbol = 'SHORT'
+    }
+
+    return { asset1Symbol, asset2Symbol }
+  }, [asset1, asset2, units])
 
   return (
     <StyledDiv>
@@ -100,30 +119,20 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         </TableCell>
         {!isZero(parseEther(asset1)) ? (
           <TableCell>
-            {isCall ? (
-              <span>
-                {numeral(asset1).format('(0.000a)')} <Units>{units}</Units>
-              </span>
-            ) : (
-              <span>
-                {numeral(asset1).format('(0.000a)')} <Units>$</Units>
-              </span>
-            )}
+            <span>
+              {numeral(asset1).format('(0.000a)')}{' '}
+              <Units>{assetSymbols().asset1Symbol}</Units>
+            </span>
           </TableCell>
         ) : (
           <TableCell>-</TableCell>
         )}
         {!isZero(parseEther(asset2)) ? (
           <TableCell>
-            {isCall ? (
-              <span>
-                {numeral(asset2).format('(0.000a)')} <Units>{units}</Units>
-              </span>
-            ) : (
-              <span>
-                {numeral(asset2).format('(0.000a)')} <Units>$</Units>
-              </span>
-            )}
+            <span>
+              {numeral(asset2).format('(0.000a)')}{' '}
+              <Units>{assetSymbols().asset2Symbol}</Units>
+            </span>
           </TableCell>
         ) : (
           <TableCell>-</TableCell>
@@ -174,13 +183,13 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
           />
         </StyledButtonCell>
       </TableRow>
-      {toggle ? (
-        <OrderTableRow onClick={() => {}}>
-          <Box column>
-            <Spacer />
+      {toggle && item.entity ? (
+        <OrderTableRow onClick={handleOnAdd} id="order-row">
+          <OrderContainer>
+            {/* <Spacer />
             <StyledTitle>
-              <Tooltip text={'Provide assets to the pool.'}>
-                {'Add Liquidity'}
+              <Tooltip text={'Manage tokens in the pool.'}>
+                {'Pool Liquidity'}
               </Tooltip>
               <CustomButton>
                 <Button variant="transparent" size="sm" onClick={handleOnClick}>
@@ -189,6 +198,15 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
               </CustomButton>
             </StyledTitle>
             <Separator />
+            <Spacer />
+
+            <Switch
+              active={true}
+              onClick={() => {}}
+              primaryText="Add"
+              secondaryText="Remove"
+            />
+
             <Spacer />
             <PriceInput
               title="Quantity"
@@ -206,8 +224,16 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
               onClick={() => {}}
               isLoading={false}
               text={'Confirm'}
+            /> */}
+
+            <Switch
+              active={true}
+              onClick={() => {}}
+              primaryText="Add"
+              secondaryText="Remove"
             />
-          </Box>
+            <AddLiquidity />
+          </OrderContainer>
         </OrderTableRow>
       ) : (
         <></>
@@ -215,6 +241,11 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
     </StyledDiv>
   )
 }
+
+const OrderContainer = styled(Box)`
+  flex-direction: column;
+  flex: 1;
+`
 
 const CustomButton = styled.div`
   margin-top: -0.1em;
@@ -264,10 +295,8 @@ const OrderTableRow = styled.div<StyleProps>`
   color: ${(props) =>
     props.isHead ? props.theme.color.grey[400] : props.theme.color.white};
   display: flex;
-  height: 25em;
   margin-left: -${(props) => props.theme.spacing[4]}px;
-  padding-left: ${(props) => props.theme.spacing[4]}px;
-  padding-right: ${(props) => props.theme.spacing[4]}px;
+  padding: ${(props) => props.theme.spacing[4]}px;
 `
 
 export default LiquidityTableRow

--- a/src/components/Market/FilterBar/FilterBar.tsx
+++ b/src/components/Market/FilterBar/FilterBar.tsx
@@ -12,8 +12,8 @@ import { ACTIVE_EXPIRIES } from '@/constants/index'
 export interface FilterBarProps {
   active: boolean
   setCallActive: any
-  expiry: number
-  setExpiry: any
+  expiry?: number
+  setExpiry?: any
 }
 
 const FilterBar: React.FC<FilterBarProps> = (props) => {
@@ -23,9 +23,6 @@ const FilterBar: React.FC<FilterBarProps> = (props) => {
     setCallActive(!active)
   }, [active, setCallActive])
 
-  const handleFilter = (event: any) => {
-    setExpiry(event.target.value)
-  }
   return (
     <StyledFilterBar>
       <LitContainer>

--- a/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -4,12 +4,10 @@ import styled from 'styled-components'
 import Box from '@/components/Box'
 import Button from '@/components/Button'
 import IconButton from '@/components/IconButton'
-import Loader from '@/components/Loader'
 import LineItem from '@/components/LineItem'
 import PriceInput from '@/components/PriceInput'
 import Spacer from '@/components/Spacer'
 import Tooltip from '@/components/Tooltip'
-import WarningLabel from '@/components/WarningLabel'
 import { Operation, UNISWAP_CONNECTOR } from '@/constants/index'
 import numeral from 'numeral'
 import formatExpiry from '@/utils/formatExpiry'
@@ -17,26 +15,18 @@ import formatExpiry from '@/utils/formatExpiry'
 import { BigNumber } from 'ethers'
 import { parseEther, formatEther } from 'ethers/lib/utils'
 
-import { useReserves } from '@/hooks/data'
 import useApprove from '@/hooks/transactions/useApprove'
 import useTokenAllowance from '@/hooks/useTokenAllowance'
 import useTokenBalance from '@/hooks/useTokenBalance'
 import useTokenTotalSupply from '@/hooks/useTokenTotalSupply'
-import useGuardCap from '@/hooks/transactions/useGuardCap'
 
 import { Trade, Market } from '@primitivefi/sdk'
 import { Fraction, Pair } from '@uniswap/sdk'
 
-import ArrowBackIcon from '@material-ui/icons/ArrowBack'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ExpandLessIcon from '@material-ui/icons/ExpandLess'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import isZero from '@/utils/isZero'
-
-import Title from '@/components/Title'
-import Description from '@/components/Description'
-import CardHeader from '@/components/CardHeader'
-import Switch from '@/components/Switch'
 import Separator from '@/components/Separator'
 
 import {
@@ -534,7 +524,7 @@ const AddLiquidity: React.FC = () => {
         </Box>
       </Column>
 
-      <Spacer />
+      <Spacer size="lg" />
 
       <Column>
         {hasLiquidity ? (
@@ -623,7 +613,7 @@ interface TabProps {
 const StyledTabPanel = styled(TabPanel)``
 const StyledTab = styled(Tab)<TabProps>`
   background-color: ${(props) =>
-    !props.active ? props.theme.color.grey[800] : props.theme.color.black};
+    !props.active ? props.theme.color.grey[800] : props.theme.color.grey[700]};
   color: ${(props) => props.theme.color.white};
   font-weight: ${(props) => (props.active ? 600 : 500)};
   padding: 0.5em 0.5em 0.5em 1em;

--- a/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -424,7 +424,9 @@ const AddLiquidity: React.FC = () => {
           </StyledTabs>
         ) : (
           <>
-            <StyledSubtitle>{noLiquidityTitle.text}</StyledSubtitle>
+            <StyledSubtitle>
+              {!loading ? noLiquidityTitle.text : null}
+            </StyledSubtitle>
             <Spacer size="sm" />
             <PriceInput
               name="primary"

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -310,37 +310,13 @@ const RemoveLiquidity: React.FC = () => {
 
   const [tab, setTab] = useState(0)
 
-  interface TabProps {
-    active?: boolean
-  }
-  const StyledTabPanel = styled(TabPanel)``
-  const StyledTab = styled(Tab)<TabProps>`
-    background-color: ${(props) =>
-      !props.active
-        ? props.theme.color.grey[800]
-        : props.theme.color.grey[700]};
-    color: ${(props) => props.theme.color.white};
-    font-weight: ${(props) => (props.active ? 600 : 500)};
-    padding: 0.5em 0.5em 0.5em 1em;
-    border-radius: 0.3em 0.3em 0 0;
-    border-width: 1px 1px 0 1px;
-    border-style: solid;
-    border-color: ${(props) => props.theme.color.grey[600]};
-    width: 50%;
-    list-style: none;
-    cursor: pointer;
-  `
-  const StyledTabList = styled(TabList)`
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-content: baseline;
-    margin-left: -2.5em;
-  `
-  const StyledTabs = styled(Tabs)`
-    width: 100%;
-    min-height: 25%;
-  `
+  useEffect(() => {
+    if (tab === 1) {
+      updateItem(item, Operation.REMOVE_LIQUIDITY, item.market)
+    } else {
+      updateItem(item, Operation.REMOVE_LIQUIDITY_CLOSE, item.market)
+    }
+  }, [tab])
 
   return (
     <LiquidityContainer id="liquidity-component">
@@ -353,23 +329,76 @@ const RemoveLiquidity: React.FC = () => {
             <StyledTab active={tab === 0}>
               <Tooltip
                 text={
-                  'Add underlying to the liquidity pool at the current premium'
+                  'Remove tokens from pool and burn options to receive only underlying tokens.'
                 }
               >
-                Pile-On
+                Exit Position
               </Tooltip>
             </StyledTab>
             <StyledTab active={tab === 1}>
-              <Tooltip text={'Add both tokens from your balance to the pool'}>
-                Add Direct
+              <Tooltip text={'Remove both tokens from the pool.'}>
+                Remove Tokens
               </Tooltip>
             </StyledTab>
           </StyledTabList>
 
           <Spacer />
 
-          <StyledTabPanel></StyledTabPanel>
           <StyledTabPanel>
+            <LineItem
+              label={'Amount'}
+              data={Math.round(10 * (ratio / 10)) / 10 + '%'}
+              units={'%'}
+            ></LineItem>
+            <Spacer size="sm" />
+            <Slider
+              min={1}
+              max={1000}
+              step={1}
+              value={ratio}
+              onChange={handleRatioChange}
+            />
+            <Spacer size="sm" />
+            <Box row justifyContent="flex-start">
+              <Button
+                variant="secondary"
+                text="25%"
+                onClick={() => {
+                  handleRatio(250)
+                }}
+              />
+              <div style={{ width: '5px' }} />
+              <Button
+                variant="secondary"
+                text="50%"
+                onClick={() => {
+                  handleRatio(500)
+                }}
+              />
+              <div style={{ width: '5px' }} />
+              <Button
+                variant="secondary"
+                text="75%"
+                onClick={() => {
+                  handleRatio(750)
+                }}
+              />
+              <div style={{ width: '5px' }} />
+              <Button
+                variant="secondary"
+                text="100%"
+                onClick={() => {
+                  handleRatio(1000)
+                }}
+              />
+            </Box>
+          </StyledTabPanel>
+          <StyledTabPanel>
+            <LineItem
+              label={'Amount'}
+              data={Math.round(10 * (ratio / 10)) / 10 + '%'}
+              units={'%'}
+            ></LineItem>
             <Spacer size="sm" />
             <Slider
               min={1}
@@ -415,7 +444,7 @@ const RemoveLiquidity: React.FC = () => {
           </StyledTabPanel>
         </StyledTabs>
 
-        <Toggle>
+        {/* <Toggle>
           <ToggleButton
             active={orderType === Operation.REMOVE_LIQUIDITY_CLOSE}
             onClick={() =>
@@ -430,10 +459,10 @@ const RemoveLiquidity: React.FC = () => {
             }
             text="Exit"
           />
-        </Toggle>
+        </Toggle> */}
         <Spacer />
 
-        <LineItem
+        {/* <LineItem
           label={'Amount'}
           data={Math.round(10 * (ratio / 10)) / 10 + '%'}
           units={'%'}
@@ -480,7 +509,7 @@ const RemoveLiquidity: React.FC = () => {
               handleRatio(1000)
             }}
           />
-        </Box>
+        </Box> */}
       </Column>
 
       <Spacer size="lg" />
@@ -663,6 +692,36 @@ const RemoveLiquidity: React.FC = () => {
   )
 }
 
+interface TabProps {
+  active?: boolean
+}
+const StyledTabPanel = styled(TabPanel)``
+const StyledTab = styled(Tab)<TabProps>`
+  background-color: ${(props) =>
+    !props.active ? props.theme.color.grey[800] : props.theme.color.grey[700]};
+  color: ${(props) => props.theme.color.white};
+  font-weight: ${(props) => (props.active ? 600 : 500)};
+  padding: 0.5em 0.5em 0.5em 1em;
+  border-radius: 0.3em 0.3em 0 0;
+  border-width: 1px 1px 0 1px;
+  border-style: solid;
+  border-color: ${(props) => props.theme.color.grey[600]};
+  width: 50%;
+  list-style: none;
+  cursor: pointer;
+`
+const StyledTabList = styled(TabList)`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-content: baseline;
+  margin-left: -2.5em;
+`
+const StyledTabs = styled(Tabs)`
+  width: 100%;
+  min-height: 25%;
+`
+
 const LiquidityContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -686,13 +745,4 @@ const Column = styled(Box)`
   flex: 1;
 `
 
-const StyledTitle = styled.h5`
-  color: ${(props) => props.theme.color.white};
-  font-size: 18px;
-  font-weight: 700;
-  margin: ${(props) => props.theme.spacing[2]}px;
-`
-const StyledRatio = styled.h4`
-  color: ${(props) => props.theme.color.white};
-`
 export default RemoveLiquidity

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -11,8 +11,10 @@ import PriceInput from '@/components/PriceInput'
 import Spacer from '@/components/Spacer'
 import Slider from '@/components/Slider'
 import Tooltip from '@/components/Tooltip'
+import Separator from '@/components/Separator'
 import Toggle from '@/components/Toggle'
 import ToggleButton from '@/components/ToggleButton'
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import { Operation, UNISWAP_CONNECTOR } from '@/constants/index'
 
 import { BigNumber } from 'ethers'
@@ -306,249 +308,384 @@ const RemoveLiquidity: React.FC = () => {
       'Withdraw the assets from the pair proportional to your share of the pool. Fees are included, and options are closed.',
   }
 
+  const [tab, setTab] = useState(0)
+
+  interface TabProps {
+    active?: boolean
+  }
+  const StyledTabPanel = styled(TabPanel)``
+  const StyledTab = styled(Tab)<TabProps>`
+    background-color: ${(props) =>
+      !props.active
+        ? props.theme.color.grey[800]
+        : props.theme.color.grey[700]};
+    color: ${(props) => props.theme.color.white};
+    font-weight: ${(props) => (props.active ? 600 : 500)};
+    padding: 0.5em 0.5em 0.5em 1em;
+    border-radius: 0.3em 0.3em 0 0;
+    border-width: 1px 1px 0 1px;
+    border-style: solid;
+    border-color: ${(props) => props.theme.color.grey[600]};
+    width: 50%;
+    list-style: none;
+    cursor: pointer;
+  `
+  const StyledTabList = styled(TabList)`
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-content: baseline;
+    margin-left: -2.5em;
+  `
+  const StyledTabs = styled(Tabs)`
+    width: 100%;
+    min-height: 25%;
+  `
+
   return (
-    <>
-      <Box row justifyContent="flex-start">
-        <IconButton
-          variant="tertiary"
-          size="sm"
-          onClick={() => updateItem(item, Operation.NONE)}
-        >
-          <ArrowBackIcon />
-        </IconButton>
+    <LiquidityContainer id="liquidity-component">
+      <Column>
+        <Separator />
         <Spacer size="sm" />
-        <StyledTitle>
-          <Tooltip text={title.tip}>{title.text}</Tooltip>
-        </StyledTitle>
-      </Box>
-      <Spacer size="sm" />
-      <Toggle>
-        <ToggleButton
-          active={orderType === Operation.REMOVE_LIQUIDITY_CLOSE}
-          onClick={() =>
-            updateItem(item, Operation.REMOVE_LIQUIDITY_CLOSE, item.market)
-          }
-          text="Exit & Close"
-        />
-        <ToggleButton
-          active={orderType === Operation.REMOVE_LIQUIDITY}
-          onClick={() =>
-            updateItem(item, Operation.REMOVE_LIQUIDITY, item.market)
-          }
-          text="Exit"
-        />
-      </Toggle>
-      <Spacer size="sm" />
-      <LineItem
-        label={'Amount'}
-        data={Math.round(10 * (ratio / 10)) / 10 + '%'}
-        units={'%'}
-      ></LineItem>
-      <Spacer size="sm" />
-      <Slider
-        min={1}
-        max={1000}
-        step={1}
-        value={ratio}
-        onChange={handleRatioChange}
-      />
 
-      <Box row justifyContent="flex-start">
-        <Button
-          variant="secondary"
-          text="25%"
-          onClick={() => {
-            handleRatio(250)
-          }}
-        />
-        <div style={{ width: '5px' }} />
-        <Button
-          variant="secondary"
-          text="50%"
-          onClick={() => {
-            handleRatio(500)
-          }}
-        />
-        <div style={{ width: '5px' }} />
-        <Button
-          variant="secondary"
-          text="75%"
-          onClick={() => {
-            handleRatio(750)
-          }}
-        />
-        <div style={{ width: '5px' }} />
-        <Button
-          variant="secondary"
-          text="100%"
-          onClick={() => {
-            handleRatio(1000)
-          }}
-        />
-      </Box>
+        <StyledTabs selectedIndex={tab} onSelect={(index) => setTab(index)}>
+          <StyledTabList>
+            <StyledTab active={tab === 0}>
+              <Tooltip
+                text={
+                  'Add underlying to the liquidity pool at the current premium'
+                }
+              >
+                Pile-On
+              </Tooltip>
+            </StyledTab>
+            <StyledTab active={tab === 1}>
+              <Tooltip text={'Add both tokens from your balance to the pool'}>
+                Add Direct
+              </Tooltip>
+            </StyledTab>
+          </StyledTabList>
 
-      <Spacer size="sm" />
-      <LineItem
-        label="This requires"
-        data={`${numeral(calculateBurn()).format('0.00')}`}
-        units={`UNI-V2 LP`}
-      />
+          <Spacer />
 
-      {orderType === Operation.REMOVE_LIQUIDITY_CLOSE ? (
-        <>
-          <Spacer size="sm" />
-          <LineItem
-            label="And requires"
-            data={`${numeral(calculateRequiredLong()).format('0.00')}`}
-            units={`LONG`}
-          />
-          {!formatEther(
-            parseEther(calculateRequiredLong()).sub(parseEther(optionBalance))
-          ) ? (
-            <>
-              <Spacer size="sm" />
-              <LineItem
-                label="You need"
-                data={`${numeral(
-                  formatEther(
-                    parseEther(calculateRequiredLong()).sub(
-                      parseEther(optionBalance)
-                    )
-                  )
-                ).format('0.00')}`}
-                units={`LONG`}
-              />{' '}
-            </>
-          ) : (
-            <> </>
-          )}{' '}
-          <Spacer size="sm" />
-          <LineItem
-            label="To receive"
-            data={numeral(calculateUnderlyingOutput()).format('0.00')}
-            units={`${entity.underlying.symbol.toUpperCase()}`}
-          />
-        </>
-      ) : (
-        <>
-          <Spacer size="sm" />
-          <LineItem
-            label="To receive"
-            data={numeral(
-              formatEther(
-                calculateRemoveOutputs().underlyingValue.raw.toString()
-              )
-            ).format('0.00')}
-            units={`${entity.underlying.symbol.toUpperCase()}`}
-          />
-          <Spacer size="sm" />
-          <LineItem
-            label="To Receive"
-            data={numeral(
-              formatEther(calculateRemoveOutputs().shortValue.raw.toString())
-            ).format('0.00')}
-            units={`SHORT`}
-          />{' '}
-        </>
-      )}
-
-      <Spacer size="sm" />
-      <IconButton
-        text="Advanced"
-        variant="transparent"
-        onClick={() => setAdvanced(!advanced)}
-      >
-        {advanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-      </IconButton>
-
-      {advanced ? (
-        <>
-          <LineItem
-            label="Short per LP token"
-            data={`${calculateLiquidityValuePerShare().shortPerLp}`}
-          />
-          <Spacer size="sm" />
-          <LineItem
-            label="Underlying per LP Token"
-            data={`${calculateLiquidityValuePerShare().underlyingPerLp}`}
-          />
-          <Spacer size="sm" />
-          <LineItem
-            label={`Total ${entity.underlying.symbol.toUpperCase()} per LP Token`}
-            data={`${calculateLiquidityValuePerShare().totalUnderlyingPerLp}`}
-          />
-          <Spacer size="sm" />
-          <LineItem
-            label={`${token0} per ${token1}`}
-            data={calculateToken0PerToken1()}
-          />
-          <Spacer size="sm" />
-          <LineItem
-            label={`${token1} per ${token0}`}
-            data={calculateToken1PerToken0()}
-          />
-          <Spacer size="sm" />
-          <LineItem
-            label={`Your Share % of Pool`}
-            data={caculatePoolShare()}
-            units={`%`}
-          />
-          <Spacer size="sm" />
-        </>
-      ) : (
-        <> </>
-      )}
-
-      <Box row justifyContent="flex-start">
-        {loading ? (
-          <div style={{ width: '100%' }}>
-            <Box column alignItems="center" justifyContent="center">
-              <Loader />
+          <StyledTabPanel></StyledTabPanel>
+          <StyledTabPanel>
+            <Spacer size="sm" />
+            <Slider
+              min={1}
+              max={1000}
+              step={1}
+              value={ratio}
+              onChange={handleRatioChange}
+            />
+            <Spacer size="sm" />
+            <Box row justifyContent="flex-start">
+              <Button
+                variant="secondary"
+                text="25%"
+                onClick={() => {
+                  handleRatio(250)
+                }}
+              />
+              <div style={{ width: '5px' }} />
+              <Button
+                variant="secondary"
+                text="50%"
+                onClick={() => {
+                  handleRatio(500)
+                }}
+              />
+              <div style={{ width: '5px' }} />
+              <Button
+                variant="secondary"
+                text="75%"
+                onClick={() => {
+                  handleRatio(750)
+                }}
+              />
+              <div style={{ width: '5px' }} />
+              <Button
+                variant="secondary"
+                text="100%"
+                onClick={() => {
+                  handleRatio(1000)
+                }}
+              />
             </Box>
-          </div>
+          </StyledTabPanel>
+        </StyledTabs>
+
+        <Toggle>
+          <ToggleButton
+            active={orderType === Operation.REMOVE_LIQUIDITY_CLOSE}
+            onClick={() =>
+              updateItem(item, Operation.REMOVE_LIQUIDITY_CLOSE, item.market)
+            }
+            text="Exit & Close"
+          />
+          <ToggleButton
+            active={orderType === Operation.REMOVE_LIQUIDITY}
+            onClick={() =>
+              updateItem(item, Operation.REMOVE_LIQUIDITY, item.market)
+            }
+            text="Exit"
+          />
+        </Toggle>
+        <Spacer />
+
+        <LineItem
+          label={'Amount'}
+          data={Math.round(10 * (ratio / 10)) / 10 + '%'}
+          units={'%'}
+        ></LineItem>
+
+        <Spacer size="sm" />
+        <Slider
+          min={1}
+          max={1000}
+          step={1}
+          value={ratio}
+          onChange={handleRatioChange}
+        />
+        <Spacer size="sm" />
+        <Box row justifyContent="flex-start">
+          <Button
+            variant="secondary"
+            text="25%"
+            onClick={() => {
+              handleRatio(250)
+            }}
+          />
+          <div style={{ width: '5px' }} />
+          <Button
+            variant="secondary"
+            text="50%"
+            onClick={() => {
+              handleRatio(500)
+            }}
+          />
+          <div style={{ width: '5px' }} />
+          <Button
+            variant="secondary"
+            text="75%"
+            onClick={() => {
+              handleRatio(750)
+            }}
+          />
+          <div style={{ width: '5px' }} />
+          <Button
+            variant="secondary"
+            text="100%"
+            onClick={() => {
+              handleRatio(1000)
+            }}
+          />
+        </Box>
+      </Column>
+
+      <Spacer size="lg" />
+
+      <Column>
+        <Separator />
+        <Spacer size="sm" />
+        <StyledInnerTitle>Order Summary</StyledInnerTitle>
+        <Spacer size="sm" />
+        <LineItem
+          label="This requires"
+          data={`${numeral(calculateBurn()).format('0.00')}`}
+          units={`UNI-V2 LP`}
+        />
+
+        {orderType === Operation.REMOVE_LIQUIDITY_CLOSE ? (
+          <>
+            <Spacer size="sm" />
+            <LineItem
+              label="And requires"
+              data={`${numeral(calculateRequiredLong()).format('0.00')}`}
+              units={`LONG`}
+            />
+            {!formatEther(
+              parseEther(calculateRequiredLong()).sub(parseEther(optionBalance))
+            ) ? (
+              <>
+                <Spacer size="sm" />
+                <LineItem
+                  label="You need"
+                  data={`${numeral(
+                    formatEther(
+                      parseEther(calculateRequiredLong()).sub(
+                        parseEther(optionBalance)
+                      )
+                    )
+                  ).format('0.00')}`}
+                  units={`LONG`}
+                />{' '}
+              </>
+            ) : (
+              <> </>
+            )}{' '}
+            <Spacer size="sm" />
+            <LineItem
+              label="To receive"
+              data={numeral(calculateUnderlyingOutput()).format('0.00')}
+              units={`${entity.underlying.symbol.toUpperCase()}`}
+            />
+          </>
         ) : (
           <>
-            {approved[1] ? (
-              <></>
-            ) : (
-              <Button
-                disabled={submitting}
-                full
-                size="sm"
-                onClick={() => handleApprove(lpToken, spender)}
-                isLoading={submitting}
-                text="Approve LP"
-              />
-            )}
-
-            {approved[0] ? (
-              <></>
-            ) : (
-              <Button
-                disabled={submitting}
-                full
-                size="sm"
-                onClick={() => handleApprove(item.entity.address, spender)}
-                isLoading={submitting}
-                text="Approve Options"
-              />
-            )}
-            {!approved[0] || !approved[1] ? null : (
-              <Button
-                disabled={submitting || ratio === 0}
-                full
-                size="sm"
-                onClick={handleSubmitClick}
-                isLoading={submitting}
-                text="Confirm Transaction"
-              />
-            )}
+            <Spacer size="sm" />
+            <LineItem
+              label="To receive"
+              data={numeral(
+                formatEther(
+                  calculateRemoveOutputs().underlyingValue.raw.toString()
+                )
+              ).format('0.00')}
+              units={`${entity.underlying.symbol.toUpperCase()}`}
+            />
+            <Spacer size="sm" />
+            <LineItem
+              label="To Receive"
+              data={numeral(
+                formatEther(calculateRemoveOutputs().shortValue.raw.toString())
+              ).format('0.00')}
+              units={`SHORT`}
+            />{' '}
           </>
         )}
-      </Box>
-    </>
+
+        <Spacer />
+        <Box row justifyContent="flex-start">
+          {loading ? (
+            <Button
+              disabled={loading}
+              full
+              size="sm"
+              onClick={() => {}}
+              isLoading={false}
+              text="Confirm"
+            />
+          ) : (
+            <>
+              {approved[1] ? (
+                <></>
+              ) : (
+                <Button
+                  disabled={submitting}
+                  full
+                  size="sm"
+                  onClick={() => handleApprove(lpToken, spender)}
+                  isLoading={submitting}
+                  text="Approve LP"
+                />
+              )}
+
+              {approved[0] ? (
+                <></>
+              ) : (
+                <Button
+                  disabled={submitting}
+                  full
+                  size="sm"
+                  onClick={() => handleApprove(item.entity.address, spender)}
+                  isLoading={submitting}
+                  text="Approve Options"
+                />
+              )}
+              {!approved[0] || !approved[1] ? null : (
+                <Button
+                  disabled={submitting || ratio === 0}
+                  full
+                  size="sm"
+                  onClick={handleSubmitClick}
+                  isLoading={submitting}
+                  text="Confirm Transaction"
+                />
+              )}
+            </>
+          )}
+        </Box>
+      </Column>
+
+      <Spacer size="lg" />
+
+      <Column>
+        <Separator />
+        <Spacer size="sm" />
+        <IconButton
+          text=""
+          variant="transparent"
+          onClick={() => setAdvanced(!advanced)}
+        >
+          <StyledInnerTitle>Advanced</StyledInnerTitle>
+          {advanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+
+        {advanced ? (
+          <>
+            {/* <LineItem
+              label="Short per LP"
+              data={`${calculateLiquidityValuePerShare().shortPerLp}`}
+            />
+            <Spacer size="sm" />
+            <LineItem
+              label="Underlying per LP"
+              data={`${calculateLiquidityValuePerShare().underlyingPerLp}`}
+            /> */}
+            <Spacer size="sm" />
+            <LineItem
+              label={`Total ${entity.underlying.symbol.toUpperCase()} per LP`}
+              data={`${calculateLiquidityValuePerShare().totalUnderlyingPerLp}`}
+            />
+            <Spacer size="sm" />
+            <LineItem
+              label={`${token0} per ${token1}`}
+              data={calculateToken0PerToken1()}
+            />
+            <Spacer size="sm" />
+            <LineItem
+              label={`${token1} per ${token0}`}
+              data={calculateToken1PerToken0()}
+            />
+            <Spacer size="sm" />
+            <LineItem
+              label={`Ownership`}
+              data={caculatePoolShare()}
+              units={`%`}
+            />
+            <Spacer size="sm" />
+          </>
+        ) : (
+          <> </>
+        )}
+      </Column>
+    </LiquidityContainer>
   )
 }
+
+const LiquidityContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+`
+
+const StyledInnerTitle = styled.div`
+  color: ${(props) => props.theme.color.white};
+  font-size: 18px;
+  font-weight: 700;
+  display: flex;
+  flex: 1;
+  width: 100%;
+  letter-spacing: 0.5px;
+  height: 44px;
+  align-items: center;
+`
+
+const Column = styled(Box)`
+  flex-direction: column;
+  flex: 1;
+`
+
 const StyledTitle = styled.h5`
   color: ${(props) => props.theme.color.white};
   font-size: 18px;

--- a/src/components/Market/OrderCard/components/Submit/Submit.tsx
+++ b/src/components/Market/OrderCard/components/Submit/Submit.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { AddLiquidity } from '../AddLiquidity'
 import { RemoveLiquidity } from '../RemoveLiquidity'
@@ -6,13 +6,14 @@ import { Swap } from '../Swap'
 import { Manage } from '../Manage'
 import { Operation } from '@/constants/index'
 
-import { useItem } from '@/state/order/hooks'
+import { useItem, useUpdateItem } from '@/state/order/hooks'
 export interface SubmitProps {
   orderType: Operation
 }
 
 const Submit: React.FC<SubmitProps> = () => {
-  const { orderType } = useItem()
+  const { item, orderType } = useItem()
+  const updateItem = useUpdateItem()
 
   let manage = false
   switch (orderType) {
@@ -31,15 +32,23 @@ const Submit: React.FC<SubmitProps> = () => {
     default:
       break
   }
+
+  useEffect(() => {
+    if (
+      orderType === Operation.ADD_LIQUIDITY ||
+      orderType === Operation.ADD_LIQUIDITY_CUSTOM ||
+      Operation.REMOVE_LIQUIDITY_CLOSE ||
+      orderType === Operation.REMOVE_LIQUIDITY
+    ) {
+      updateItem(item, Operation.LONG)
+    }
+  }, [orderType, updateItem, item])
   return (
     <StyledDiv>
       {orderType === Operation.ADD_LIQUIDITY ||
-      orderType === Operation.ADD_LIQUIDITY_CUSTOM ? (
-        <AddLiquidity />
-      ) : orderType === Operation.REMOVE_LIQUIDITY_CLOSE ||
-        orderType === Operation.REMOVE_LIQUIDITY ? (
-        <RemoveLiquidity />
-      ) : manage ? (
+      orderType === Operation.ADD_LIQUIDITY_CUSTOM ? null : orderType ===
+          Operation.REMOVE_LIQUIDITY_CLOSE ||
+        orderType === Operation.REMOVE_LIQUIDITY ? null : manage ? (
         <Manage />
       ) : (
         <>

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -362,9 +362,11 @@ const Swap: React.FC = () => {
   }, [tokenBalance, onUserInput])
 
   const handleToggleClick = useCallback(() => {
+    const prevTypedValue = typedValue
     setCallActive(!active)
     updateItem(item, !active ? Operation.LONG : Operation.CLOSE_LONG)
-  }, [active, setCallActive])
+    onUserInput(prevTypedValue ? prevTypedValue : '0')
+  }, [active, setCallActive, typedValue, onUserInput])
 
   const handleSubmitClick = useCallback(() => {
     submitOrder(

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -184,7 +184,7 @@ const Swap: React.FC = () => {
   )
 
   const handleSetMax = useCallback(() => {
-    if (orderType === Operation.LONG) {
+    if (orderType === Operation.LONG && !parseEther(prem).isZero()) {
       const maxOptions = parseEther(tokenBalance)
         .mul(parseEther('1'))
         .div(parseEther(prem))

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -184,8 +184,15 @@ const Swap: React.FC = () => {
   )
 
   const handleSetMax = useCallback(() => {
-    tokenBalance && onUserInput(tokenBalance)
-  }, [tokenBalance, onUserInput])
+    if (orderType === Operation.LONG) {
+      const maxOptions = parseEther(tokenBalance)
+        .mul(parseEther('1'))
+        .div(parseEther(prem))
+      onUserInput(formatEther(maxOptions))
+    } else {
+      tokenBalance && onUserInput(tokenBalance)
+    }
+  }, [tokenBalance, onUserInput, prem])
 
   const handleToggleClick = useCallback(() => {
     const prevTypedValue = typedValue
@@ -270,7 +277,7 @@ const Swap: React.FC = () => {
     if (item.market && inputLoading) {
       calculateTotalCost()
     }
-  }, [item, parsedAmount, inputLoading, item.market])
+  }, [item, parsedAmount, inputLoading, item.market, typedValue, orderType])
 
   const calculateProportionalShort = useCallback(() => {
     const sizeWei = parsedAmount

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -1,0 +1,149 @@
+import React, { useCallback } from 'react'
+import styled from 'styled-components'
+import numeral from 'numeral'
+import { parseEther, formatEther } from 'ethers/lib/utils'
+import { BigNumber, BigNumberish } from 'ethers'
+
+import { Operation } from '@primitivefi/sdk'
+import { TokenAmount } from '@uniswap/sdk'
+
+const formatParsedAmount = (amount: BigNumberish) => {
+  const bigAmt = BigNumber.from(amount)
+  return numeral(formatEther(bigAmt)).format(
+    bigAmt.lt(parseEther('0.01')) ? '0.0000' : '0.00'
+  )
+}
+
+export interface OptionTextInfoProps {
+  orderType?: Operation
+  parsedAmount?: BigNumber
+  isPut?: boolean
+  strike?: TokenAmount
+  underlying?: TokenAmount
+  debit?: TokenAmount
+  credit?: TokenAmount
+  short?: TokenAmount
+}
+
+const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
+  orderType,
+  parsedAmount,
+  isPut,
+  strike,
+  underlying,
+  debit,
+  credit,
+  short,
+}) => {
+  const getOrderTitle = useCallback(() => {
+    switch (orderType) {
+      case Operation.LONG:
+        return 'BUY'
+      case Operation.SHORT:
+        return 'BUY'
+      case Operation.WRITE:
+        return 'SELL TO OPEN'
+      default:
+        return 'SELL'
+    }
+  }, [orderType])
+
+  const calculateProportionalShort = useCallback(() => {
+    return parsedAmount.mul(strike.raw.toString()).div(parseEther('1'))
+  }, [parsedAmount, orderType, strike])
+
+  return (
+    <StyledSpan>
+      You will <StyledData>{getOrderTitle()}</StyledData>{' '}
+      <StyledData>
+        {' '}
+        {formatParsedAmount(parsedAmount)}{' '}
+        {orderType === Operation.SHORT || orderType === Operation.CLOSE_SHORT
+          ? 'SHORT'
+          : ''}{' '}
+        {isPut ? 'PUT' : 'CALL'}{' '}
+      </StyledData>
+      {orderType === Operation.CLOSE_LONG || orderType === Operation.WRITE ? (
+        <>
+          for{' '}
+          <StyledData>
+            {formatParsedAmount(credit.raw.toString())} {credit.token.symbol}
+          </StyledData>
+          .{' '}
+        </>
+      ) : orderType === Operation.CLOSE_SHORT ? (
+        <>
+          for{' '}
+          <StyledData>
+            {formatParsedAmount(short.raw.toString())} {short.token.symbol}
+          </StyledData>
+          .{' '}
+        </>
+      ) : orderType === Operation.SHORT ? (
+        <>
+          for{' '}
+          <StyledData>
+            {' '}
+            {formatParsedAmount(short.raw.toString())} {short.token.symbol}
+          </StyledData>{' '}
+          which gives you the right to withdraw{' '}
+          <StyledData>
+            {formatParsedAmount(
+              parsedAmount.mul(strike.raw.toString()).div(parseEther('1'))
+            )}{' '}
+            {underlying.token.symbol}
+          </StyledData>{' '}
+          when the options expire unexercised, or the right to redeem them for{' '}
+          <StyledData>
+            {' '}
+            {formatParsedAmount(parsedAmount)} {strike.token.symbol}
+          </StyledData>{' '}
+          if they are exercised.{' '}
+        </>
+      ) : orderType === Operation.LONG ? (
+        <>
+          for{' '}
+          <StyledData>
+            {formatParsedAmount(debit.raw.toString())} {debit.token.symbol}
+          </StyledData>{' '}
+          which gives you the right to purchase{' '}
+          <StyledData>
+            {formatParsedAmount(parsedAmount)} {underlying.token.symbol}
+          </StyledData>{' '}
+          for{' '}
+          <StyledData>
+            {formatParsedAmount(calculateProportionalShort())}{' '}
+            {strike.token.symbol}
+          </StyledData>
+          .{' '}
+        </>
+      ) : (
+        <>
+          which gives you the right to purchase{' '}
+          <StyledData>
+            {underlying.raw.toString()} {underlying.token.symbol}
+          </StyledData>{' '}
+          for{' '}
+          <StyledData>
+            {isPut ? +strike.raw.toString() : +strike.raw.toString()}{' '}
+            {strike.token.symbol}
+          </StyledData>
+          .{' '}
+        </>
+      )}
+    </StyledSpan>
+  )
+}
+
+const StyledSpan = styled.span`
+  color: ${(props) => props.theme.color.grey[400]};
+`
+
+const StyledData = styled.span`
+  color: ${(props) => props.theme.color.white};
+  font-size: 16px;
+  font-weight: 500;
+  text-transform: uppercase;
+`
+
+export default OptionTextInfo

--- a/src/components/OptionTextInfo/index.ts
+++ b/src/components/OptionTextInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OptionTextInfo'

--- a/src/components/Separator/Separator.tsx
+++ b/src/components/Separator/Separator.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Separator: React.FC = () => {
+  return <StyledSeparator />
+}
+
+interface StyledSeparatorProps {
+  size: number
+}
+
+const StyledSeparator = styled.div`
+  border: 1px solid ${(props) => props.theme.color.grey[600]};
+  width: 100%;
+`
+
+export default Separator

--- a/src/components/Separator/index.ts
+++ b/src/components/Separator/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Separator'

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import styled from 'styled-components'
+import Toggle from '@/components/Toggle'
+import ToggleButton from '@/components/ToggleButton'
+
+interface SwitchProps {
+  active: boolean
+  onClick: () => void
+}
+
+const Switch: React.FC<SwitchProps> = ({ active, onClick }) => {
+  return (
+    <StyledToggleContainer>
+      <StyledFilterBarInner>
+        <Toggle full>
+          <ToggleButton active={active} onClick={onClick} text="Buy" />
+          <ToggleButton active={!active} onClick={onClick} text="Sell" />
+        </Toggle>
+      </StyledFilterBarInner>
+    </StyledToggleContainer>
+  )
+}
+
+const StyledToggleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+`
+
+const StyledFilterBarInner = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  height: ${(props) => props.theme.barHeight}px;
+  width: 100%;
+`
+
+export default Switch

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -8,6 +8,7 @@ interface SwitchProps {
   onClick: () => void
   primaryText?: string
   secondaryText?: string
+  variant?: 'primary' | 'secondary' | 'transparent' | 'outlined'
 }
 
 const Switch: React.FC<SwitchProps> = ({
@@ -15,6 +16,7 @@ const Switch: React.FC<SwitchProps> = ({
   onClick,
   primaryText,
   secondaryText,
+  variant,
 }) => {
   return (
     <StyledToggleContainer>

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -6,15 +6,30 @@ import ToggleButton from '@/components/ToggleButton'
 interface SwitchProps {
   active: boolean
   onClick: () => void
+  primaryText?: string
+  secondaryText?: string
 }
 
-const Switch: React.FC<SwitchProps> = ({ active, onClick }) => {
+const Switch: React.FC<SwitchProps> = ({
+  active,
+  onClick,
+  primaryText,
+  secondaryText,
+}) => {
   return (
     <StyledToggleContainer>
       <StyledFilterBarInner>
         <Toggle full>
-          <ToggleButton active={active} onClick={onClick} text="Buy" />
-          <ToggleButton active={!active} onClick={onClick} text="Sell" />
+          <ToggleButton
+            active={active}
+            onClick={onClick}
+            text={primaryText ? primaryText : 'Buy'}
+          />
+          <ToggleButton
+            active={!active}
+            onClick={onClick}
+            text={secondaryText ? secondaryText : 'Sell'}
+          />
         </Toggle>
       </StyledFilterBarInner>
     </StyledToggleContainer>

--- a/src/components/Switch/index.ts
+++ b/src/components/Switch/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Switch'

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface TitleProps {
+  align?: string
+  margin?: number
+  full?: boolean
+  dark?: boolean
+  weight?: number
+}
+
+const Title: React.FC<TitleProps> = ({
+  children,
+  align,
+  margin,
+  full,
+  dark,
+  weight,
+}) => {
+  return (
+    <StyledTitle
+      align={align}
+      margin={margin}
+      full={full}
+      dark={dark}
+      weight={weight}
+    >
+      {children}
+    </StyledTitle>
+  )
+}
+
+const StyledTitle = styled.div<TitleProps>`
+  align-items: ${(props) => (props.align ? props.align : 'center')};
+  color: ${(props) =>
+    props.dark ? props.theme.color.black : props.theme.color.white};
+  font-size: 16px;
+  font-weight: ${(props) => (props.weight ? props.weight : 700)};
+  margin: ${(props) => props.theme.spacing[props.margin ? props.margin : 2]}px;
+  display: flex;
+  flex: 1;
+  width: ${(props) => (props.full ? '100%' : null)};
+  letter-spacing: 0.5px;
+  justify-content: space-between;
+`
+
+export default Title

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -37,6 +37,18 @@ const StyledTitle = styled.div<TitleProps>`
   font-size: 16px;
   font-weight: ${(props) => (props.weight ? props.weight : 700)};
   margin: ${(props) => props.theme.spacing[props.margin ? props.margin : 2]}px;
+  margin-right: ${(props) =>
+    props.margin
+      ? props.margin === 0
+        ? 0
+        : props.theme.spacing[2]
+      : props.theme.spacing[2]}px;
+  margin-left: ${(props) =>
+    props.margin
+      ? props.margin === 0
+        ? 0
+        : props.theme.spacing[2]
+      : props.theme.spacing[2]}px;
   display: flex;
   flex: 1;
   width: ${(props) => (props.full ? '100%' : null)};

--- a/src/components/Title/index.ts
+++ b/src/components/Title/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Title'

--- a/src/pages/liquidity/[...id].tsx
+++ b/src/pages/liquidity/[...id].tsx
@@ -10,6 +10,7 @@ import Disclaimer from '@/components/Disclaimer'
 import MetaMaskOnboarding from '@metamask/onboarding'
 
 import Notifs from '@/components/Notifs'
+import Tooltip from '@/components/Tooltip'
 
 import { useActiveWeb3React } from '@/hooks/user/index'
 import ErrorBoundary from '@/components/ErrorBoundary'
@@ -20,6 +21,9 @@ import { useClearNotif } from '@/state/notifs/hooks'
 import { useSetLoading } from '@/state/positions/hooks'
 
 import LiquidityTable from '@/components/Liquidity/LiquidityTable'
+import numeral from 'numeral'
+import { formatEther } from 'ethers/lib/utils'
+import isZero from '@/utils/isZero'
 
 import PositionsCard from '@/components/Market/PositionsCard'
 
@@ -41,6 +45,7 @@ interface CardProps {
 }
 
 export const DataCard: React.FC<CardProps> = ({
+  children,
   title,
   description,
   multiplier,
@@ -51,11 +56,18 @@ export const DataCard: React.FC<CardProps> = ({
         <CardTitle>{title ? title : 'No title'}</CardTitle>
       </CardContent>
       <CardContent>
-        <Text>{description ? description : 'No description'}</Text>
+        <Text>
+          {description ? description : children ? children : 'No description'}
+        </Text>
       </CardContent>
     </StyledCardContainer>
   )
 }
+
+const StyledL = styled(Box)`
+  margin-top: -1.5em;
+  margin-bottom: -1.1em;
+`
 
 export const Graph: React.FC = () => {
   return <Box>Graph</Box>
@@ -155,13 +167,44 @@ const Liquidity = ({ user, data }) => {
           <StyledLitContainer>
             <StyledLitContainerContent>
               <StyledHeaderContainer>
-                <DataCard
-                  title={'Total Liquidity'}
-                  multiplier={3}
-                  description={'10 WETH'}
-                />
-                <DataCard multiplier={3} />
-                <DataCard multiplier={3} />
+                <DataCard title={'Total Call Liquidity'} multiplier={2}>
+                  {!options.loading ? (
+                    !isZero(options.reservesTotal[0]) ? (
+                      <>
+                        {`${numeral(
+                          formatEther(options.reservesTotal[0])
+                        ).format('0.00a')} ${' '} ${true ? 'weth' : 'DAI'}`}
+                      </>
+                    ) : (
+                      <Tooltip text={`Choose an option and add liquidity!`}>
+                        None
+                      </Tooltip>
+                    )
+                  ) : (
+                    <>
+                      <Loader size="sm" />
+                    </>
+                  )}
+                </DataCard>
+                <DataCard title={'Total Put Liquidity'} multiplier={2}>
+                  {!options.loading ? (
+                    !isZero(options.reservesTotal[1]) ? (
+                      <>
+                        {`${numeral(
+                          formatEther(options.reservesTotal[1])
+                        ).format('0.00a')} ${' '} ${'DAI'}`}
+                      </>
+                    ) : (
+                      <Tooltip text={`Choose an option and add liquidity!`}>
+                        None
+                      </Tooltip>
+                    )
+                  ) : (
+                    <>
+                      <Loader size="sm" />
+                    </>
+                  )}
+                </DataCard>
               </StyledHeaderContainer>
               <Spacer />
               <StyledHeaderContainer>
@@ -197,12 +240,15 @@ interface CardContainerProps {
 }
 
 const StyledCardContainer = styled.span<CardContainerProps>`
-  background: ${(props) => props.theme.color.grey[900]};
-  border: 1px solid grey;
+  background: ${(props) => props.theme.color.grey[800]};
+  //border: 1px solid grey;
   border-radius: ${(props) => props.theme.borderRadius}px;
   margin: ${(props) => props.theme.spacing[3]}px;
   padding: ${(props) => props.theme.spacing[2]}px;
   width: ${(props) => props.theme.contentWidth * (1 / props.multiplier)}px;
+  justify-content: center;
+  display: flex;
+  flex-direction: column;
 `
 
 const CardTitle = styled.span`
@@ -211,6 +257,8 @@ const CardTitle = styled.span`
   opacity: 0.5;
   letter-spacing: 1px;
   text-transform: uppercase;
+  display: flex;
+  justify-content: center;
 `
 
 const Text = styled.span`
@@ -219,11 +267,14 @@ const Text = styled.span`
   font-weight: 700;
   letter-spacing: 1px;
   text-transform: uppercase;
+  display: flex;
+  justify-content: center;
 `
 
 const CardContent = styled(Box)`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   padding: ${(props) => props.theme.spacing[2]}px;
 `
 

--- a/src/pages/liquidity/[...id].tsx
+++ b/src/pages/liquidity/[...id].tsx
@@ -73,6 +73,10 @@ const Liquidity = ({ user, data }) => {
   const setLoading = useSetLoading()
 
   useEffect(() => {
+    updateOptions('weth')
+  }, [user])
+
+  useEffect(() => {
     const { ethereum, web3 } = window as any
 
     if (MetaMaskOnboarding.isMetaMaskInstalled() && (!ethereum || !web3)) {
@@ -162,7 +166,6 @@ const Liquidity = ({ user, data }) => {
               <Spacer />
               <StyledHeaderContainer>
                 <LiquidityTable />
-                <Text>{user}</Text>
               </StyledHeaderContainer>
             </StyledLitContainerContent>
           </StyledLitContainer>

--- a/src/pages/liquidity/[...id].tsx
+++ b/src/pages/liquidity/[...id].tsx
@@ -20,12 +20,18 @@ import { useOptions, useUpdateOptions } from '@/state/options/hooks'
 import { useClearNotif } from '@/state/notifs/hooks'
 import { useSetLoading } from '@/state/positions/hooks'
 
+import { Grid, Col, Row } from 'react-styled-flexboxgrid'
+
 import LiquidityTable from '@/components/Liquidity/LiquidityTable'
 import numeral from 'numeral'
 import { formatEther } from 'ethers/lib/utils'
 import isZero from '@/utils/isZero'
 
 import PositionsCard from '@/components/Market/PositionsCard'
+import Switch from '@/components/Switch'
+import MarketHeader from '@/components/Market/MarketHeader'
+import FilterBar from '@/components/Market/FilterBar'
+import { useRemoveItem } from '@/state/order/hooks'
 
 export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   const data = params?.id
@@ -83,9 +89,10 @@ const Liquidity = ({ user, data }) => {
   const options = useOptions()
   const updateOptions = useUpdateOptions()
   const setLoading = useSetLoading()
+  const removeItem = useRemoveItem()
 
   useEffect(() => {
-    updateOptions('weth')
+    updateOptions('weth') //hardcoded
   }, [user])
 
   useEffect(() => {
@@ -164,67 +171,64 @@ const Liquidity = ({ user, data }) => {
       ) : (
         <>
           <Disclaimer />
-          <StyledLitContainer>
-            <StyledLitContainerContent>
-              <StyledHeaderContainer>
-                <DataCard title={'Total Call Liquidity'} multiplier={2}>
-                  {!options.loading ? (
-                    !isZero(options.reservesTotal[0]) ? (
-                      <>
-                        {`${numeral(
-                          formatEther(options.reservesTotal[0])
-                        ).format('0.00a')} ${' '} ${true ? 'weth' : 'DAI'}`}
-                      </>
-                    ) : (
-                      <Tooltip text={`Choose an option and add liquidity!`}>
-                        None
-                      </Tooltip>
-                    )
-                  ) : (
-                    <>
-                      <Loader size="sm" />
-                    </>
-                  )}
-                </DataCard>
-                <DataCard title={'Total Put Liquidity'} multiplier={2}>
-                  {!options.loading ? (
-                    !isZero(options.reservesTotal[1]) ? (
-                      <>
-                        {`${numeral(
-                          formatEther(options.reservesTotal[1])
-                        ).format('0.00a')} ${' '} ${'DAI'}`}
-                      </>
-                    ) : (
-                      <Tooltip text={`Choose an option and add liquidity!`}>
-                        None
-                      </Tooltip>
-                    )
-                  ) : (
-                    <>
-                      <Loader size="sm" />
-                    </>
-                  )}
-                </DataCard>
-              </StyledHeaderContainer>
-              <Spacer />
-              <StyledHeaderContainer>
-                <LiquidityTable />
-              </StyledHeaderContainer>
-            </StyledLitContainerContent>
-          </StyledLitContainer>
+          <StyledMarket>
+            <Grid id={'market-grid'}>
+              <Row>
+                <StyledLitContainer>
+                  <div>
+                    <StyledHeaderContainer>
+                      <MarketHeader
+                        marketId={'weth'}
+                        isCall={callPutActive ? 0 : 1}
+                      />
+                      <FilterBar
+                        active={callPutActive}
+                        setCallActive={() => setCallPutActive(!callPutActive)}
+                      />
+                    </StyledHeaderContainer>
+
+                    <StyledHeaderContainer>
+                      <LiquidityTable callActive={callPutActive} />
+                    </StyledHeaderContainer>
+                  </div>
+                </StyledLitContainer>
+              </Row>
+            </Grid>
+          </StyledMarket>
         </>
       )}
     </ErrorBoundary>
   )
 }
 
-const StyledLitContainer = styled.div`
+const StyledMarket = styled.div`
+  width: 100%;
+  height: 90%;
+  position: absolute;
+  overflow-x: hidden;
+  overflow-y: auto !important;
+  &::-webkit-scrollbar {
+    width: 5px;
+    height: 15px;
+  }
+
+  &::-webkit-scrollbar-track-piece {
+    background-color: ${(props) => props.theme.color.grey[800]};
+  }
+
+  &::-webkit-scrollbar-thumb:vertical {
+    height: 30px;
+    background-color: ${(props) => props.theme.color.grey[700]};
+  }
+  scrollbar-color: ${(props) => props.theme.color.grey[700]}
+    ${(props) => props.theme.color.grey[800]};
+  scrollbar-width: thin;
+`
+
+export const StyledLitContainer = styled(Col)`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-`
-const StyledLitContainerContent = styled.div`
-  width: ${(props) => props.theme.contentWidth}px;
 `
 
 const StyledHeaderContainer = styled.div`
@@ -276,6 +280,14 @@ const CardContent = styled(Box)`
   flex-direction: column;
   justify-content: center;
   padding: ${(props) => props.theme.spacing[2]}px;
+`
+const StyledContainer = styled(Col)`
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  flex-grow: 1;
 `
 
 export default Liquidity

--- a/src/pages/markets/index.tsx
+++ b/src/pages/markets/index.tsx
@@ -7,6 +7,7 @@ import { Grid, Col, Row } from 'react-styled-flexboxgrid'
 import { useClearNotif } from '@/state/notifs/hooks'
 import { useClearOptions } from '@/state/options/hooks'
 import { useClearPositions } from '@/state/positions/hooks'
+import { useRemoveItem } from '@/state/order/hooks'
 
 const days: { [key: number]: React.ReactNode } = {
   1: (
@@ -96,6 +97,7 @@ const Markets: React.FC = () => {
   const clear = useClearNotif()
   const clearOptions = useClearOptions()
   const clearPositions = useClearPositions()
+  const removeItem = useRemoveItem()
 
   const isItPiDay = (dateObject) => {
     const date = dateObject.getDate()
@@ -113,6 +115,7 @@ const Markets: React.FC = () => {
     const currentDay = date.getDay()
     clearOptions()
     clearPositions()
+    removeItem()
     if (isItPiDay(date)) {
       setDay(8)
     } else {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -42,7 +42,7 @@ const theme = {
     mediaQuery: 'only screen',
     container: {
       sm: 54, // rem
-      md: 70, // rem
+      md: 78, // rem
       lg: 85, // rem
     },
     breakpoints: {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -55,6 +55,7 @@ const theme = {
   rowHeight: 64,
   sidebarWidth: 25,
   spacing: {
+    0: 0,
     1: 4,
     2: 8,
     3: 16,

--- a/src/utils/tryParseAmount.ts
+++ b/src/utils/tryParseAmount.ts
@@ -7,6 +7,8 @@ export function tryParseAmount(value?: string): BigNumber | undefined {
     value === '0' ||
     value === '.' ||
     value === undefined ||
+    value === '00' ||
+    value.startsWith('00') ||
     (value.indexOf('0') === 0 && value.indexOf('.') === 1)
   ) {
     if (value.length >= 3 && value.substr(2, 1) !== '.') {


### PR DESCRIPTION
Opening this PR to start review of it... it will probably need a few more pushes before its done. Will try to summarize the changes and to dos left:

- Fixes #437 
- Fixes #435 
- Fixes #433
- Fixes #432 
- Fixes #431 
- Fixes #429 
- Removes <AddLiquidity/> and <RemoveLiquidity/> from the order card.
- Removes <OrderContent/> from the order card (the list of all order types).
- When the order card is triggered (option selected), the <Swap/> component is rendered.
- Changes active position items, only displays the option details and the total value they hold for LONG options. Also updates UI.
- Related to #432, removes extra columns in table, and uses single data pieces. Adds expiry column.
- Related to #433, removes expiry dropdown in favor of expiry column.
- Related to #437, improves all components in <Swap/> including <PriceInput/>, <Input/>, <Description/>, <Title/>, <Switch/>
- Updates greeks to display the correctly formatted values (was doing incorrect math).
- Adds a "Liquidity" view at the href `/liquidity/0xaddress`. TO DO: `/liquidity/` is incomplete, check it out.
- Recycles several components from `Market` view.
- New `LiquidityTable` and related components that displays all options, filtered out if expired (unless active position is still held).
- Embeds <AddLiquidity/> and <RemoveLiquidity/> into the <LiquidityTableRow/> drawers!


To do
- `/liquidity/` page needs to have something, maybe an overview?
- Make sure this refactor is executing transactions correctly, maybe I should deploy testnet?
- Swap component description button isn't closing the description when clicked.
- Greek drawer doesnt open when you click on the first option row.
- Clickaway is a little glitchy on the liquidity drawers with AddLiquidity component, need a better  ref? I'm using clickAway to reset the `orderType` state, since `orderType` state is shared in market page.
- UpdateOptions() defaults to `/market/` which sometimes happens on refreshing the `/liquidity/` page.