### PR TITLE
fix(max-button): Fixes a max button. Description. Pool share calcs.

### DIFF
--- a/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -103,7 +103,7 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
           : 0
         : 0
       blackScholes.setRiskFree(0)
-      blackScholes.setDeviation(1)
+      blackScholes.setDeviation(1.5) // Fix: should not be hardcoded
       blackScholes.setPrice(price)
       const delta = blackScholes.delta()
       const theta = blackScholes.theta()

--- a/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -85,6 +85,11 @@ const AddLiquidity: React.FC = () => {
     }
   }, [setHasL, item])
 
+  const underlyingAssetSymbol = useCallback(() => {
+    const symbol = entity.isPut ? 'DAI' : item.asset.toUpperCase()
+    return symbol === '' ? entity.underlying.symbol.toUpperCase() : symbol
+  }, [item])
+
   const lpToken = item.market ? item.market.liquidityToken.address : ''
   const token0 = item.market ? item.market.token0.symbol : ''
   const token1 = item.market ? item.market.token1.symbol : ''
@@ -150,6 +155,11 @@ const AddLiquidity: React.FC = () => {
 
   const handleSetMax = useCallback(() => {
     onUnderInput(underlyingTokenBalance)
+  }, [underlyingTokenBalance, onUnderInput])
+
+  const handleSetDoubleInputMax = useCallback(() => {
+    onUnderInput(formatEther(parseEther(underlyingTokenBalance).div(3)))
+    onOptionInput(formatEther(parseEther(underlyingTokenBalance).mul(2).div(3)))
   }, [underlyingTokenBalance, onUnderInput])
 
   const handleSubmitClick = useCallback(() => {
@@ -265,16 +275,30 @@ const AddLiquidity: React.FC = () => {
     )
     const poolShare =
       supply.gt(0) && parsedAmount.gt(0)
-        ? lpMinted.divide(tSupply.add(lpMinted))
-        : new Fraction('0')
+        ? BigNumber.from(lpMinted.raw.toString())
+            .mul(parseEther('1'))
+            .div(
+              BigNumber.from(tSupply.raw.toString()).add(
+                lpMinted.raw.toString()
+              )
+            )
+        : parseEther('0')
 
-    const newPoolShare = poolShare
-      .add(
-        supply.gt(0) ? lpHold.divide(tSupply.add(lpMinted)) : new Fraction('0')
+    const newPoolShare = formatEther(
+      BigNumber.from(poolShare).add(
+        supply.gt(0)
+          ? BigNumber.from(lpHold.raw.toString())
+              .mul(parseEther('1'))
+              .div(
+                BigNumber.from(tSupply.raw.toString()).add(
+                  lpMinted.raw.toString()
+                )
+              )
+          : parseEther('0')
       )
-      .multiply('100')
-      .toSignificant(6)
-    const addedPoolShare = poolShare.multiply('100').toSignificant(6)
+    )
+
+    const addedPoolShare = formatEther(poolShare.mul('100'))
     return { addedPoolShare, newPoolShare }
   }, [
     item.market,
@@ -380,9 +404,9 @@ const AddLiquidity: React.FC = () => {
 
   const noLiquidityTitle = {
     text:
-      'This pair has no liquidity, adding liquidity will initialize this market and set an initial token ratio.',
+      'This pair has no liquidity, adding liquidity will initialize this market and set an initial token ratio. The Long input should be greater than the underlying input.',
     tip:
-      'Providing liquidity to this pair will set the ratio between the tokens.',
+      'Providing liquidity to this pair will set the ratio between the tokens. Total deposit of underlying tokens is the sum of the inputs.',
   }
 
   return (
@@ -391,7 +415,7 @@ const AddLiquidity: React.FC = () => {
       {hasLiquidity ? (
         <PriceInput
           name="primary"
-          title={`Underlying`}
+          title={underlyingAssetSymbol()}
           quantity={underlyingValue}
           onChange={handleUnderInput}
           onClick={handleSetMax}
@@ -413,27 +437,31 @@ const AddLiquidity: React.FC = () => {
           <Spacer size="sm" />
           <PriceInput
             name="primary"
-            title={`LONG Input`}
+            title={entity.isCall ? 'Call Options' : 'Put Options'}
             quantity={optionValue}
             onChange={handleOptionInput}
-            onClick={() => console.log('Max unavailable.')} //
+            onClick={handleSetDoubleInputMax}
           />
           <Spacer />
           <PriceInput
             name="secondary"
-            title={`Underlying Input`}
+            title={underlyingAssetSymbol()}
             quantity={underlyingValue}
             onChange={handleUnderInput}
-            onClick={() => console.log('Max unavailable.')} //
+            onClick={handleSetDoubleInputMax}
             balance={underlyingAmount}
           />
         </>
       )}
       <Spacer />
       <LineItem
-        label="LP for"
-        data={formatEther(calculateOptionsAddedAsLiquidity())}
-        units={`LONG`}
+        label="Total Deposit"
+        data={formatEther(
+          hasLiquidity
+            ? parsedUnderlyingAmount
+            : parsedUnderlyingAmount.add(parsedOptionAmount)
+        )}
+        units={underlyingAssetSymbol()}
       />
       <Spacer size="sm" />
       {!hasLiquidity || tab === 1 ? (
@@ -450,7 +478,7 @@ const AddLiquidity: React.FC = () => {
       )}
       <LineItem
         label="Receive"
-        data={!hasLiquidity ? '0.00' : calculatePoolShare().addedPoolShare}
+        data={!hasLiquidity ? '100' : calculatePoolShare().addedPoolShare}
         units={`% of Pool`}
       />
 
@@ -487,10 +515,7 @@ const AddLiquidity: React.FC = () => {
               disabled={
                 !approved[0] ||
                 !parsedUnderlyingAmount?.gt(0) ||
-                (hasLiquidity ? null : !parsedOptionAmount?.gt(0)) ||
-                (item.entity.isCall
-                  ? parseFloat(underlyingValue) >= 1000
-                  : parseFloat(underlyingValue) >= 100000)
+                (hasLiquidity ? null : !parsedOptionAmount?.gt(0))
               }
               full
               size="sm"

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -210,6 +210,11 @@ const Swap: React.FC = () => {
         .mul(parseEther('1'))
         .div(parseEther(prem))
       onUserInput(formatEther(maxOptions))
+    } else if (
+      orderType === Operation.CLOSE_LONG &&
+      !parseEther(prem).isZero()
+    ) {
+      onUserInput(tokenBalance)
     } else {
       tokenBalance && onUserInput(tokenBalance)
     }
@@ -442,8 +447,9 @@ const Swap: React.FC = () => {
 
         {error ? (
           <Description>
-            <Spacer />
+            <Spacer size="sm" />
             <WarningLabel>Order quantity too large!</WarningLabel>
+            <Spacer size="sm" />
           </Description>
         ) : null}
         <StyledEnd row justifyContent="flex-start">


### PR DESCRIPTION
- CalculatePoolShare() in AddLiquidity breaks the "max" button in production when attempting to add liquidity, fixed that.
- Updated add liquidity when no liquidity to have "total deposit" line.
- Updates symbols in the inputs instead of "option input" and "underlying input"
- Fixes max button for CLOSE_LONG order type in swap component
- Updates hardcoded IV for greeks