### PR TITLE
Fix/puts multiplier

### DIFF
--- a/src/components/Market/OptionsTable/OptionsTable.tsx
+++ b/src/components/Market/OptionsTable/OptionsTable.tsx
@@ -131,6 +131,9 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
 
   const formatTableColumns = useCallback(
     (option: any): TableColumns => {
+      const multiplier: BigNumber = option.entity.isPut
+        ? BigNumber.from(option.entity.baseValue.raw.toString())
+        : parseEther('1')
       const tableKey: string = option.entity.address
       const tableAssset: string = asset.toUpperCase()
       const tableStrike: string = option.entity.strikePrice.toString()
@@ -138,7 +141,9 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
         option.entity.getBreakeven(
           BigNumber.from(
             option.entity.isPut
-              ? option.market.spotOpenPremium.raw.toString()
+              ? multiplier
+                  .mul(option.market.spotOpenPremium.raw.toString())
+                  .div(parseEther('1'))
               : parseEther(
                   calculatePremiumInDollars(
                     option.market.spotOpenPremium.raw.toString()
@@ -148,7 +153,11 @@ const OptionsTable: React.FC<OptionsTableProps> = (props) => {
         )
       ).toString()
       const tableBid: string = formatEtherBalance(
-        option.market.spotClosePremium.raw.toString()
+        option.entity.isPut
+          ? multiplier
+              .mul(option.market.spotClosePremium.raw.toString())
+              .div(parseEther('1'))
+          : option.market.spotClosePremium.raw.toString()
       ).toString()
       const tableAsk: string = formatEtherBalance(
         option.market.spotOpenPremium.raw.toString()

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -420,7 +420,11 @@ const Swap: React.FC = () => {
           quantity={typedValue}
           onClick={handleSetMax}
           balance={
-            orderType === Operation.LONG ? underlyingAmount : tokenAmount
+            orderType === Operation.LONG
+              ? underlyingAmount
+              : entity.isPut
+              ? underlyingAmount
+              : tokenAmount
           }
         />
         <Spacer size="sm" />

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -65,11 +65,15 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
       </StyledData>
       {orderType === Operation.CLOSE_LONG || orderType === Operation.WRITE ? (
         <>
-          for{' '}
+          using{' '}
+          <StyledData>
+            {formatParsedAmount(parsedAmount)} {credit.token.symbol}
+          </StyledData>{' '}
+          as collateral for{' '}
           <StyledData>
             {formatParsedAmount(credit.raw.toString())} {credit.token.symbol}
-          </StyledData>
-          .{' '}
+          </StyledData>{' '}
+          in premium.{' '}
         </>
       ) : orderType === Operation.CLOSE_SHORT ? (
         <>
@@ -77,7 +81,7 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
           <StyledData>
             {formatParsedAmount(short.raw.toString())} {short.token.symbol}
           </StyledData>
-          .{' '}
+          in premium.{' '}
         </>
       ) : orderType === Operation.SHORT ? (
         <>

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -49,8 +49,11 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
   }, [orderType])
 
   const calculateProportionalShort = useCallback(() => {
+    if (isPut) {
+      return parsedAmount.mul(parseEther('1')).div(underlying.raw.toString())
+    }
     return parsedAmount.mul(strike.raw.toString()).div(parseEther('1'))
-  }, [parsedAmount, orderType, strike])
+  }, [parsedAmount, orderType, strike, isPut])
 
   return (
     <StyledSpan>
@@ -65,7 +68,7 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
       </StyledData>
       {orderType === Operation.CLOSE_LONG || orderType === Operation.WRITE ? (
         <>
-          using{' '}
+          by depositing{' '}
           <StyledData>
             {formatParsedAmount(parsedAmount)} {credit.token.symbol}
           </StyledData>{' '}
@@ -105,22 +108,41 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
           if they are exercised.{' '}
         </>
       ) : orderType === Operation.LONG ? (
-        <>
-          for{' '}
-          <StyledData>
-            {formatParsedAmount(debit.raw.toString())} {debit.token.symbol}
-          </StyledData>{' '}
-          which gives you the right to purchase{' '}
-          <StyledData>
-            {formatParsedAmount(parsedAmount)} {underlying.token.symbol}
-          </StyledData>{' '}
-          for{' '}
-          <StyledData>
-            {formatParsedAmount(calculateProportionalShort())}{' '}
-            {strike.token.symbol}
-          </StyledData>
-          .{' '}
-        </>
+        isPut ? (
+          <>
+            for{' '}
+            <StyledData>
+              {formatParsedAmount(debit.raw.toString())} {debit.token.symbol}
+            </StyledData>{' '}
+            which gives you the right to sell{' '}
+            <StyledData>
+              {formatParsedAmount(calculateProportionalShort())}{' '}
+              {strike.token.symbol}
+            </StyledData>{' '}
+            for{' '}
+            <StyledData>
+              {formatParsedAmount(parsedAmount)} {underlying.token.symbol}
+            </StyledData>
+            .{' '}
+          </>
+        ) : (
+          <>
+            for{' '}
+            <StyledData>
+              {formatParsedAmount(debit.raw.toString())} {debit.token.symbol}
+            </StyledData>{' '}
+            which gives you the right to purchase{' '}
+            <StyledData>
+              {formatParsedAmount(parsedAmount)} {underlying.token.symbol}
+            </StyledData>{' '}
+            for{' '}
+            <StyledData>
+              {formatParsedAmount(calculateProportionalShort())}{' '}
+              {strike.token.symbol}
+            </StyledData>
+            .{' '}
+          </>
+        )
       ) : (
         <>
           which gives you the right to purchase{' '}
@@ -129,7 +151,7 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
           </StyledData>{' '}
           for{' '}
           <StyledData>
-            {isPut ? +strike.raw.toString() : +strike.raw.toString()}{' '}
+            {formatParsedAmount(parseEther('1').div(strike.raw.toString()))}{' '}
             {strike.token.symbol}
           </StyledData>
           .{' '}

--- a/src/components/PriceInput/PriceInput.tsx
+++ b/src/components/PriceInput/PriceInput.tsx
@@ -7,6 +7,7 @@ import Label from '@/components/Label'
 import Spacer from '@/components/Spacer'
 import Box from '@/components/Box'
 import { BigNumberish } from 'ethers'
+import Tooltip from '@/components/Tooltip'
 
 import { TokenAmount, JSBI } from '@uniswap/sdk'
 
@@ -21,6 +22,7 @@ export interface PriceInputProps {
   startAdornment?: React.ReactNode
   balance?: TokenAmount
   valid?: boolean
+  tip?: string
 }
 
 const PriceInput: React.FC<PriceInputProps> = ({
@@ -32,12 +34,20 @@ const PriceInput: React.FC<PriceInputProps> = ({
   startAdornment,
   balance,
   valid,
+  tip,
 }) => {
   return (
     <StyledContainer>
       {balance ? (
         <Box row justifyContent="space-between">
-          <Label text={title} />
+          {tip ? (
+            <Tooltip text={tip}>
+              <Label text={title} />
+            </Tooltip>
+          ) : (
+            <Label text={title} />
+          )}
+
           <ContainerSpan>
             <LeftSpan>
               <OpacitySpan>Max</OpacitySpan>

--- a/src/components/PriceInput/PriceInput.tsx
+++ b/src/components/PriceInput/PriceInput.tsx
@@ -102,6 +102,9 @@ const LeftSpan = styled.span`
 
 const RightSpan = styled.span`
   align-self: flex-end;
+  &:hover {
+    opacity: 0.55;
+  }
 `
 
 const OpacitySpan = styled.span`


### PR DESCRIPTION
- Adds put multiplier to table columns for puts
- Fixes add liquidity bug when there is no liquidity and typing in the second input triggers to the primary input to be 0.
- Adds put multiplier to implied price when adding liquidity to a market with no liquidity
- Adds a put multiplier line to put order cards to show the info
- Updates max options to include put multiplier
- Adds opacity change when hovering max button
- Updates order size in the swap component to include the multiplier
- Premium and slippage calculations take into account the put multiplier
- Adds condition to the price input for swap component on the sell order type to display the underlying balance if selling to open
- Fixes optiontext info component for puts
- 