### PR TITLE
Fix/add liq logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.10.0",
     "@metamask/onboarding": "^1.0.0",
-    "@primitivefi/sdk": "0.3.2",
+    "@primitivefi/sdk": "0.3.3",
     "@primitivefi/v1-connectors": "1.2.2",
     "@reduxjs/toolkit": "^1.4.0",
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -136,13 +136,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
   const shortTokenBalance = useTokenBalance(entity.redeem.address)
   const lp = useTokenBalance(lpToken)
   const lpTotalSupply = useTokenTotalSupply(lpToken)
-  /* useEffect(() => {
-    if (provide && item) {
-      updateItem(item, Operation.ADD_LIQUIDITY, market)
-    } else if (item) {
-      updateItem(item, Operation.REMOVE_LIQUIDITY_CLOSE, market)
-    }
-  }, [provide, item, updateItem]) */
+
   const calculatePoolShare = useCallback(() => {
     const supply = BigNumber.from(parseEther(lpTotalSupply).toString())
     if (typeof market === 'undefined' || market === null || supply.isZero())
@@ -175,17 +169,6 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         totalUnderlyingPerLp: '0',
       }
 
-    /*  const [
-      shortValue,
-      underlyingValue,
-      totalUnderlyingValue,
-    ] = market.getLiquidityValuePerShare(
-      new TokenAmount(
-        market.liquidityToken,
-        parseEther(lpTotalSupply).toString()
-      )
-    ) */
-
     const shortValue = market.getLiquidityValue(
       entity.redeem,
       new TokenAmount(
@@ -211,15 +194,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         .add(underlyingValue.raw.toString())
         .toString()
     )
-    /* const shortPerLp = parseEther(lp)
-      .mul(shortValue.raw.toString())
-      .div(parseEther('1'))
-    const underlyingPerLp = parseEther(lp)
-      .mul(underlyingValue.raw.toString())
-      .div(parseEther('1'))
-    const totalUnderlyingPerLp = parseEther(lp)
-      .mul(totalUnderlyingValue.raw.toString())
-      .div(parseEther('1')) */
+
     const shortPerLp = shortValue.raw.toString()
     const underlyingPerLp = underlyingValue.raw.toString()
     const totalUnderlyingPerLp = totalUnderlyingValue.raw.toString()
@@ -237,28 +212,6 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         underlyingPerLp: '0',
         totalUnderlyingPerLp: '0',
       }
-
-    /* const [
-      shortValue,
-      underlyingValue,
-      totalUnderlyingValue,
-    ] = market.getLiquidityValuePerShare(
-      new TokenAmount(
-        market.liquidityToken,
-        parseEther(lpTotalSupply).toString()
-      )
-    )
-    const shortPerLp = parseEther(lpTotalSupply)
-      .mul(shortValue.raw.toString())
-      .div(parseEther('1'))
-    const underlyingPerLp = parseEther(lpTotalSupply)
-      .mul(underlyingValue.raw.toString())
-      .div(parseEther('1'))
-    const totalUnderlyingPerLp = parseEther(lpTotalSupply)
-      .mul(totalUnderlyingValue.raw.toString())
-      .div(parseEther('1'))
-
-    return { shortPerLp, underlyingPerLp, totalUnderlyingPerLp } */
     const shortValue = market.getLiquidityValue(
       entity.redeem,
       new TokenAmount(
@@ -290,15 +243,7 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
         .add(underlyingValue.raw.toString())
         .toString()
     )
-    /* const shortPerLp = parseEther(lp)
-      .mul(shortValue.raw.toString())
-      .div(parseEther('1'))
-    const underlyingPerLp = parseEther(lp)
-      .mul(underlyingValue.raw.toString())
-      .div(parseEther('1'))
-    const totalUnderlyingPerLp = parseEther(lp)
-      .mul(totalUnderlyingValue.raw.toString())
-      .div(parseEther('1')) */
+
     const shortPerLp = shortValue.raw.toString()
     const underlyingPerLp = underlyingValue.raw.toString()
     const totalUnderlyingPerLp = totalUnderlyingValue.raw.toString()

--- a/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
+++ b/src/components/Liquidity/LiquidityTable/LiquidityTableRow/LiquidityTableRow.tsx
@@ -4,7 +4,7 @@ import TableRow from '@/components/TableRow'
 import TableCell from '@/components/TableCell'
 
 import { BigNumber } from 'ethers'
-import { parseEther, formatEther } from 'ethers/lib/utils'
+import { parseEther, formatEther, parseUnits } from 'ethers/lib/utils'
 import numeral from 'numeral'
 import isZero from '@/utils/isZero'
 import formatExpiry from '@/utils/formatExpiry'
@@ -419,7 +419,13 @@ const LiquidityTableRow: React.FC<LiquidityTableRowProps> = ({
               <StyledTitle>
                 <LineItem
                   label={'Asset Balance'}
-                  data={numeral(underlyingTokenBalance).format('0.00')}
+                  data={numeral(
+                    parseEther(underlyingTokenBalance).gt(
+                      parseUnits('1', 'gwei')
+                    )
+                      ? underlyingTokenBalance
+                      : '0'
+                  ).format('0.00')}
                   units={asset}
                 />
                 <Spacer />

--- a/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
+++ b/src/components/Market/OptionsTable/OptionsTableRow/OptionsTableRow.tsx
@@ -160,7 +160,7 @@ const OptionsTableRow: React.FC<OptionsTableRowProps> = ({
         <TableCell>
           {!isZero(parseEther(bid)) ? (
             <span>
-              {numeral(breakeven).format('0.00a')} <Units>DAI</Units>
+              {numeral(breakeven).format('(0.00)')} <Units>DAI</Units>
             </span>
           ) : (
             <>{`-`}</>

--- a/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -167,7 +167,6 @@ const AddLiquidity: React.FC = () => {
       submitOrder(
         library,
         BigInt(parsedUnderlyingAmount.toString()),
-
         orderType,
         BigInt(parsedUnderlyingAmount.toString())
       )
@@ -188,18 +187,6 @@ const AddLiquidity: React.FC = () => {
     parsedUnderlyingAmount,
     orderType,
   ])
-
-  const calculateToken0PerToken1 = useCallback(() => {
-    if (typeof item.market === 'undefined' || item.market === null) return '0'
-    const ratio = item.market.token1Price.raw.toSignificant(2)
-    return ratio
-  }, [item.market])
-
-  const calculateToken1PerToken0 = useCallback(() => {
-    if (typeof item.market === 'undefined' || item.market === null) return '0'
-    const ratio = item.market.token0Price.raw.toSignificant(2)
-    return ratio
-  }, [item.market])
 
   // the quantity of options supplied as liquidity for the 'pile-on' order type is not equal to the parsed amount input.
   // optionsAdded = totalUnderlyingTokensAdded (parsed amount sum) / (strikeRatio * reserveB / reserveA + 1)
@@ -299,6 +286,18 @@ const AddLiquidity: React.FC = () => {
     )
 
     const addedPoolShare = formatEther(poolShare.mul('100'))
+    console.log(
+      `
+      totalSupply: ${lpTotalSupply.toString()}
+      tSupply: ${formatEther(tSupply.raw.toString())}
+      amountA: ${formatEther(amountADesired)}
+      amountB: ${formatEther(amountBDesired)}
+      lpMinted: ${formatEther(lpMinted.raw.toString())}
+      poolShare: ${formatEther(poolShare)}
+      newPoolShare: ${newPoolShare}
+      addedPoolShare: ${addedPoolShare}
+      `
+    )
     return { addedPoolShare, newPoolShare }
   }, [
     item.market,
@@ -308,36 +307,6 @@ const AddLiquidity: React.FC = () => {
     parsedUnderlyingAmount,
     calculateOptionsAddedAsLiquidity,
   ])
-
-  const calculateLiquidityValuePerShare = useCallback(() => {
-    if (
-      typeof item.market === 'undefined' ||
-      item.market === null ||
-      BigNumber.from(parseEther(lpTotalSupply)).isZero()
-    )
-      return {
-        shortPerLp: '0',
-        underlyingPerLp: '0',
-        totalUnderlyingPerLp: '0',
-      }
-
-    const [
-      shortValue,
-      underlyingValue,
-      totalUnderlyingValue,
-    ] = item.market.getLiquidityValuePerShare(
-      new TokenAmount(
-        item.market.liquidityToken,
-        parseEther(lpTotalSupply).toString()
-      )
-    )
-    const shortPerLp = formatEther(shortValue.raw.toString())
-    const underlyingPerLp = formatEther(underlyingValue.raw.toString())
-    const totalUnderlyingPerLp = formatEther(
-      totalUnderlyingValue.raw.toString()
-    )
-    return { shortPerLp, underlyingPerLp, totalUnderlyingPerLp }
-  }, [item.market, lp, lpTotalSupply])
 
   const getPutMultiplier = useCallback(() => {
     const multiplier = entity.isPut

--- a/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -11,7 +11,7 @@ import Spacer from '@/components/Spacer'
 // Utilities
 import { Operation, UNISWAP_CONNECTOR } from '@/constants/index'
 import { BigNumber } from 'ethers'
-import { parseEther, formatEther } from 'ethers/lib/utils'
+import { parseEther, formatEther, parseUnits } from 'ethers/lib/utils'
 import isZero from '@/utils/isZero'
 
 // Hooks
@@ -114,6 +114,9 @@ const AddLiquidity: React.FC = () => {
   )
 
   const handleSetMax = useCallback(() => {
+    if (parseEther(underlyingTokenBalance).lt(parseUnits('1', 'gwei'))) {
+      return null
+    }
     onUnderInput(parseFloat(underlyingTokenBalance).toPrecision(15))
   }, [underlyingTokenBalance, onUnderInput])
 

--- a/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/AddLiquidity/AddLiquidity.tsx
@@ -44,7 +44,7 @@ const AddLiquidity: React.FC = () => {
   // notifs
   const addNotif = useAddNotif()
   // option entity in order
-  const { item, orderType, approved, loading } = useItem()
+  const { item, orderType, loading, approved } = useItem()
   // inputs for user quantity
   const { optionValue, underlyingValue } = useLP()
   const { onOptionInput, onUnderInput } = useLiquidityActionHandlers()
@@ -94,9 +94,9 @@ const AddLiquidity: React.FC = () => {
   )
   const handleUnderInput = useCallback(
     (value: string) => {
-      if (value === '') {
+      /* if (value === '') {
         value = '0'
-      }
+      } */
       onUnderInput(value)
       if (hasLiquidity) {
         onOptionInput(
@@ -114,7 +114,7 @@ const AddLiquidity: React.FC = () => {
   )
 
   const handleSetMax = useCallback(() => {
-    onUnderInput(underlyingTokenBalance)
+    onUnderInput(parseFloat(underlyingTokenBalance).toPrecision(15))
   }, [underlyingTokenBalance, onUnderInput])
 
   // ==== Transaction Handling ====
@@ -195,6 +195,7 @@ const AddLiquidity: React.FC = () => {
     const optionsInput = BigNumber.from(inputAmount.raw.toString()) // IN UNITS OF BASE VALUE
       .mul(parseEther('1'))
       .div(denominator)
+
     return optionsInput.toString()
   }, [item.market, lpTotalSupply, parsedOptionAmount, parsedUnderlyingAmount])
 
@@ -229,6 +230,12 @@ const AddLiquidity: React.FC = () => {
         item.market.reserveOf(entity.underlying).raw.toString()
       ).toString()
     )
+
+    console.log(`
+      optionsInput: ${formatEther(optionsInput)}
+      amountADesired: ${formatEther(amountADesired.raw.toString())}
+      amountBDesired: ${formatEther(amountBDesired.raw.toString())}
+    `)
 
     if (
       isZero(amountADesired.raw.toString()) ||

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -400,7 +400,7 @@ const RemoveLiquidity: React.FC = () => {
                       ? entity.strike.symbol.toLowerCase()
                       : entity.underlying.symbol.toLowerCase()
                   )}`}
-                  text={`Step 1. Buy ${numeral(
+                  text={`1) Buy ${numeral(
                     formatEther(requiresAdditionalLong())
                   ).format('0.00')} Options`}
                 />{' '}
@@ -419,7 +419,7 @@ const RemoveLiquidity: React.FC = () => {
                 isLoading={submitting}
                 text={
                   requiresAdditionalLong().gt(0)
-                    ? 'Step 2. Remove Liquidity'
+                    ? '2) Remove Liquidity'
                     : 'Remove Liquidity'
                 }
               />

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -125,43 +125,6 @@ const RemoveLiquidity: React.FC = () => {
     handleRatioChange,
   ])
 
-  const calculateToken0PerToken1 = useCallback(() => {
-    if (
-      typeof item.market === 'undefined' ||
-      !item.market.hasLiquidity ||
-      item.market === null
-    )
-      return '0'
-    const ratio = item.market.token1Price.raw.toSignificant(2)
-    return ratio
-  }, [item.market])
-
-  const calculateToken1PerToken0 = useCallback(() => {
-    if (
-      typeof item.market === 'undefined' ||
-      !item.market.hasLiquidity ||
-      item.market === null
-    )
-      return '0'
-    const ratio = item.market.token0Price.raw.toSignificant(2)
-    return ratio
-  }, [item.market])
-
-  const caculatePoolShare = useCallback(() => {
-    if (
-      typeof item.market === 'undefined' ||
-      item.market === null ||
-      !item.market.hasLiquidity
-    )
-      return '0'
-    const poolShare = BigNumber.from(parseEther(lpTotalSupply)).gt(0)
-      ? BigNumber.from(parseEther(lp))
-          .mul(parseEther('1'))
-          .div(parseEther(lpTotalSupply))
-      : '0'
-    return (Number(formatEther(poolShare)) * 100).toFixed(2)
-  }, [item.market, lp, lpTotalSupply])
-
   const calculateUnderlyingOutput = useCallback(() => {
     if (
       typeof item.market === 'undefined' ||
@@ -273,12 +236,6 @@ const RemoveLiquidity: React.FC = () => {
       .div(parseEther('1000'))
     return formatEther(liquidity)
   }, [item.market, lp, ratio])
-
-  const title = {
-    text: 'Withdraw Liquidity',
-    tip:
-      'Withdraw the assets from the pair proportional to your share of the pool. Fees are included, and options are closed.',
-  }
 
   return (
     <LiquidityContainer>

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -237,6 +237,13 @@ const RemoveLiquidity: React.FC = () => {
     return formatEther(liquidity)
   }, [item.market, lp, ratio])
 
+  const requiresAdditionalLong = useCallback(() => {
+    const additional = parseEther(calculateRequiredLong()).sub(
+      parseEther(optionBalance)
+    )
+    return additional
+  }, [calculateRequiredLong, optionBalance])
+
   return (
     <LiquidityContainer>
       <Spacer />
@@ -300,20 +307,14 @@ const RemoveLiquidity: React.FC = () => {
             data={`${numeral(calculateRequiredLong()).format('0.00a')}`}
             units={`LONG`}
           />
-          {!formatEther(
-            parseEther(calculateRequiredLong()).sub(parseEther(optionBalance))
-          ) ? (
+          {requiresAdditionalLong().gt(0) ? (
             <>
               <Spacer size="sm" />
               <LineItem
                 label="You need"
-                data={`${numeral(
-                  formatEther(
-                    parseEther(calculateRequiredLong()).sub(
-                      parseEther(optionBalance)
-                    )
-                  )
-                ).format('0.00a')}`}
+                data={`${numeral(formatEther(requiresAdditionalLong())).format(
+                  '0.00a'
+                )}`}
                 units={`LONG`}
               />{' '}
             </>
@@ -389,14 +390,36 @@ const RemoveLiquidity: React.FC = () => {
                 text="Approve Options"
               />
             )}
+            {requiresAdditionalLong().gt(0) ? (
+              <>
+                <Button
+                  full
+                  size="sm"
+                  href={`/markets/${encodeURIComponent(
+                    entity.underlying.symbol.toUpperCase() === 'DAI'
+                      ? entity.strike.symbol.toLowerCase()
+                      : entity.underlying.symbol.toLowerCase()
+                  )}`}
+                  text="Step 1. Buy Long"
+                />{' '}
+              </>
+            ) : (
+              <> </>
+            )}
             {!approved[0] || !approved[1] ? null : (
               <Button
-                disabled={submitting || ratio === 0}
+                disabled={
+                  submitting || ratio === 0 || requiresAdditionalLong().gt(0)
+                }
                 full
                 size="sm"
                 onClick={handleSubmitClick}
                 isLoading={submitting}
-                text="Remove Liquidity"
+                text={
+                  requiresAdditionalLong().gt(0)
+                    ? 'Step 2. Remove Liquidity'
+                    : 'Remove Liquidity'
+                }
               />
             )}
           </>

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -162,38 +162,6 @@ const RemoveLiquidity: React.FC = () => {
     return (Number(formatEther(poolShare)) * 100).toFixed(2)
   }, [item.market, lp, lpTotalSupply])
 
-  const calculateLiquidityValuePerShare = useCallback(() => {
-    if (
-      typeof item.market === 'undefined' ||
-      item.market === null ||
-      !item.market.hasLiquidity ||
-      BigNumber.from(parseEther(lpTotalSupply)).isZero()
-    )
-      return {
-        shortPerLp: '0',
-        underlyingPerLp: '0',
-        totalUnderlyingPerLp: '0',
-      }
-
-    const [
-      shortValue,
-      underlyingValue,
-      totalUnderlyingValue,
-    ] = item.market.getLiquidityValuePerShare(
-      new TokenAmount(
-        item.market.liquidityToken,
-        parseEther(lpTotalSupply).toString()
-      )
-    )
-    const shortPerLp = formatEther(shortValue.raw.toString())
-    const underlyingPerLp = formatEther(underlyingValue.raw.toString())
-    const totalUnderlyingPerLp = formatEther(
-      totalUnderlyingValue.raw.toString()
-    )
-
-    return { shortPerLp, underlyingPerLp, totalUnderlyingPerLp }
-  }, [item.market, lp, lpTotalSupply])
-
   const calculateUnderlyingOutput = useCallback(() => {
     if (
       typeof item.market === 'undefined' ||

--- a/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/components/Market/OrderCard/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -400,7 +400,9 @@ const RemoveLiquidity: React.FC = () => {
                       ? entity.strike.symbol.toLowerCase()
                       : entity.underlying.symbol.toLowerCase()
                   )}`}
-                  text="Step 1. Buy Long"
+                  text={`Step 1. Buy ${numeral(
+                    formatEther(requiresAdditionalLong())
+                  ).format('0.00')} Options`}
                 />{' '}
               </>
             ) : (

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -298,13 +298,7 @@ const Swap: React.FC = () => {
             orderType,
             size
           )
-          console.log(
-            `
-            spot: ${spot.raw.toString()}
-            actual: ${actualPremium.raw.toString()}
-            slip: ${slip.toString()}
-            `
-          )
+
           setImpact(slip)
           setPrem(formatEther(spot.raw.toString()))
         }

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -227,7 +227,6 @@ const Swap: React.FC = () => {
         .div(parseEther(prem))
         .mul(parseEther('1'))
         .div(getPutMultiplier())
-      console.log(prem)
       onUserInput(formatEther(maxOptions))
     } else if (
       orderType === Operation.CLOSE_LONG &&
@@ -241,7 +240,9 @@ const Swap: React.FC = () => {
 
   const handleSubmitClick = useCallback(() => {
     const orderSize = entity.isPut
-      ? parsedAmount.mul(entity.baseValue.raw.toString()).div(parseEther('1'))
+      ? parsedAmount
+          .mul(entity.baseValue.raw.toString())
+          .div(entity.quoteValue.raw.toString())
       : parsedAmount
     submitOrder(library, BigInt(orderSize), orderType, BigInt('0'))
   }, [submitOrder, item, library, parsedAmount, orderType, entity.isPut])
@@ -255,7 +256,9 @@ const Swap: React.FC = () => {
       let credit = '0'
       let short = '0'
       const size = entity.isPut
-        ? parsedAmount.mul(entity.baseValue.raw.toString()).div(parseEther('1'))
+        ? parsedAmount
+            .mul(entity.baseValue.raw.toString())
+            .div(entity.quoteValue.raw.toString())
         : parsedAmount
       let actualPremium: TokenAmount
       let spot: TokenAmount
@@ -266,12 +269,20 @@ const Swap: React.FC = () => {
             orderType,
             size
           )
+          console.log(
+            `
+            spot: ${spot.raw.toString()}
+            actual: ${actualPremium.raw.toString()}
+            slip: ${slip.toString()}
+            `
+          )
           setImpact(slip)
           setPrem(formatEther(spot.raw.toString()))
         }
         if (orderType === Operation.LONG) {
           if (parsedAmount.gt(BigNumber.from(0))) {
             debit = formatEther(actualPremium.raw.toString())
+            console.log(debit, formatEther(size))
           } else {
             setImpact('0.00')
             setPrem(formatEther(item.market.spotOpenPremium.raw.toString()))
@@ -349,7 +360,7 @@ const Swap: React.FC = () => {
       .catch((error) => {
         addNotif(0, `Approving ${item.asset.toUpperCase()}`, error.message, '')
       })
-  }, [item, onApprove])
+  }, [item, onApprove, tokenAddress, spender])
 
   const handleSecondaryApproval = useCallback(() => {
     onApprove(secondaryAddress, spender)
@@ -357,7 +368,7 @@ const Swap: React.FC = () => {
       .catch((error) => {
         addNotif(0, `Approving ${item.asset.toUpperCase()}`, error.message, '')
       })
-  }, [item, onApprove])
+  }, [item, onApprove, secondaryAddress, spender])
 
   const removeItem = useRemoveItem()
 

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -101,7 +101,7 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
           for{' '}
           <StyledData>
             {formatParsedAmount(short.raw.toString())} {short.token.symbol}
-          </StyledData>
+          </StyledData>{' '}
           in premium.{' '}
         </>
       ) : orderType === Operation.SHORT ? (

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -43,6 +43,10 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
         return 'BUY'
       case Operation.WRITE:
         return 'SELL TO OPEN'
+      case Operation.CLOSE_LONG:
+        return 'SELL TO CLOSE'
+      case Operation.CLOSE_SHORT:
+        return 'BUY TO CLOSE'
       default:
         return 'SELL'
     }
@@ -60,7 +64,13 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
       You will <StyledData>{getOrderTitle()}</StyledData>{' '}
       <StyledData>
         {' '}
-        {formatParsedAmount(parsedAmount)}{' '}
+        {isPut
+          ? formatParsedAmount(
+              parsedAmount
+                .mul(strike.raw.toString())
+                .div(underlying.raw.toString())
+            )
+          : formatParsedAmount(parsedAmount)}{' '}
         {orderType === Operation.SHORT || orderType === Operation.CLOSE_SHORT
           ? 'SHORT'
           : ''}{' '}

--- a/src/state/order/hooks.tsx
+++ b/src/state/order/hooks.tsx
@@ -238,6 +238,7 @@ export const useUpdateItem = (): ((
               : isUniswap
               ? UNISWAP_CONNECTOR[chainId]
               : SUSHISWAP_CONNECTOR[chainId]
+
           let tokenAddress
           let secondaryAddress
           switch (orderType) {
@@ -328,7 +329,7 @@ export const useHandleSubmitOrder = (): ((
       const optionEntity: Option = item.entity
       const signer: ethers.Signer = await provider.getSigner()
       const tradeSettings: TradeSettings = {
-        slippage: slippage,
+        slippage: '0.00',
         timeLimit: DEFAULT_TIMELIMIT,
         receiver: account,
         deadline: DEFAULT_DEADLINE,

--- a/src/state/order/hooks.tsx
+++ b/src/state/order/hooks.tsx
@@ -329,7 +329,7 @@ export const useHandleSubmitOrder = (): ((
       const optionEntity: Option = item.entity
       const signer: ethers.Signer = await provider.getSigner()
       const tradeSettings: TradeSettings = {
-        slippage: '0.00',
+        slippage: '0.0',
         timeLimit: DEFAULT_TIMELIMIT,
         receiver: account,
         deadline: DEFAULT_DEADLINE,
@@ -439,6 +439,7 @@ export const useHandleSubmitOrder = (): ((
           )
           break
         case Operation.ADD_LIQUIDITY:
+          tradeSettings.slippage = '0.01'
           // primary input is the options deposit (underlying tokens)
           trade.inputAmount = new TokenAmount(
             optionEntity,
@@ -456,6 +457,7 @@ export const useHandleSubmitOrder = (): ((
           )
           break
         case Operation.ADD_LIQUIDITY_CUSTOM:
+          tradeSettings.slippage = '0.01'
           // primary input is the options deposit (underlying tokens)
           trade.inputAmount = new TokenAmount(
             optionEntity.redeem,
@@ -472,6 +474,7 @@ export const useHandleSubmitOrder = (): ((
           )
           break
         case Operation.REMOVE_LIQUIDITY:
+          tradeSettings.slippage = '0.01'
           trade.inputAmount = new TokenAmount(
             optionEntity.redeem,
             parsedAmountA.toString()
@@ -486,6 +489,7 @@ export const useHandleSubmitOrder = (): ((
           )
           break
         case Operation.REMOVE_LIQUIDITY_CLOSE:
+          tradeSettings.slippage = '0.01'
           trade.inputAmount = new TokenAmount(
             optionEntity.redeem,
             parsedAmountA.toString()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,10 +2103,10 @@
   resolved "https://registry.yarnpkg.com/@primitivefi/contracts/-/contracts-0.4.4.tgz#082de30bf71b4895bd767b916cb9d641a430f783"
   integrity sha512-J2JzR36lwmnWHCgGakPm5bRCKqAtixJFTjkBbiJ31ZmKGrjxKBCMeOmJzSbGbqXUyTYfT/Mfik6tZ+oZEQL8bA==
 
-"@primitivefi/sdk@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@primitivefi/sdk/-/sdk-0.3.2.tgz#b5a2fd1ef75487311b553374ba235ce36fa07017"
-  integrity sha512-ZgvCYGZALfey1pOqORKUOn2bH1kdoDR3+OGxZZJwRI9zbaLewQsne13zRhClWYjgh8fPLCNTLgqmaSSY7ssnpw==
+"@primitivefi/sdk@0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@primitivefi/sdk/-/sdk-0.3.3.tgz#7a0249c8208900b81fa4d31762a84e5ebe19aa31"
+  integrity sha512-EZKfiOIcX4YVBh3enrCZJ70IzyhdpUwDKdDWDFNkd3+FwI3E7s4KJASe/euqs+C1P1VE6PGUOv3ii6GEwOUYAQ==
   dependencies:
     "@ethersproject/providers" "^5.0.5"
     "@primitivefi/contracts" "0.4.4"


### PR DESCRIPTION
Lots of changes...

- Adds two set removal process by adding a "Step 1. Buy xxxx Options" button.
- Fixes a bug with double slippage calculations causing an incorrect transaction execution for swaps.
- Fixes an approval error bug in remove liquidity because of missing deps in the handleApprove callback.
- Updates positions card to display scaled long/short option amounts.
- Updates max buttons to handle amounts correctly. Removes max buttons that are ambigious like in the dual add liquidity view, and when buying long options. (Max long options to buy is the option price / underlying token balance, but price has slippage changed based on size... so its not an easy math equation).
- Updates optionTextInfo to display the correct info for order types, and puts
- Changes the tradeSettings.slippage value to 0 for everything except add/remove liquidity. This value needs to at least be '0.01' when removing liquidity. This is the source of the double slippage impact on the regular swaps (buy long, sell long, etc.)
- Updates to sdk v0.3.3 which fixes a critical math calculation error when adding liquidity to puts.