### PR TITLE
Fix/short

### DIFF
--- a/src/components/LeaderboardTable/index.tsx
+++ b/src/components/LeaderboardTable/index.tsx
@@ -1,0 +1,212 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import styled from 'styled-components'
+import { Grid, Col, Row } from 'react-styled-flexboxgrid'
+
+import IconButton from '@/components/IconButton'
+import Button from '@/components/Button'
+import Tooltip from '@/components/Tooltip'
+import Box from '@/components/Box'
+import Table from '@/components/Table'
+import TableBody from '@/components/TableBody'
+import TableCell from '@/components/TableCell'
+import TableRow from '@/components/TableRow'
+import LitContainer from '@/components/LitContainer'
+import Spacer from '@/components/Spacer'
+import MetaMaskOnboarding from '@metamask/onboarding'
+import { useRouter } from 'next/router'
+import { useActiveWeb3React } from '@/hooks/user/index'
+import { SUSHISWAP_CONNECTOR } from '@primitivefi/sdk'
+import SushiSwapConnectorABI from '@primitivefi/v1-connectors/deployments/live/UniswapConnector03.json'
+import ethers from 'ethers'
+
+export interface SpecificationMetaData {
+  score: string
+  name: string
+  id: string
+}
+
+export const ADDRESS: { [key: string]: string } = {
+  '0x152Ac2bC1821C5C9ecA56D1F35D8b0D8b61187F5': 'alexangel.eth',
+  zero: 'zero',
+}
+
+export const SCORE: { [key: string]: string } = {
+  '0x152Ac2bC1821C5C9ecA56D1F35D8b0D8b61187F5': '1337',
+  zero: 'zero',
+}
+
+export const SPECIFICATIONS: SpecificationMetaData[] = Object.keys(ADDRESS).map(
+  (key): SpecificationMetaData => {
+    return {
+      name: ADDRESS[key],
+      score: SCORE[key],
+      id: key,
+    }
+  }
+)
+
+const getConnector = async (signer): Promise<ethers.Contract> => {
+  const chain = await signer.getChainId()
+  const connectorAddr = SUSHISWAP_CONNECTOR[chain]
+  const registry = new ethers.Contract(
+    connectorAddr,
+    SushiSwapConnectorABI.abi,
+    signer
+  )
+  return registry
+}
+
+const getAddressFromEvent = async (
+  provider,
+  contract,
+  event,
+  eventArgs
+): Promise<any> => {
+  const filter: any = contract.filters[event](...eventArgs)
+  filter.fromBlock = 7200000 // we can set a better start block later
+  filter.toBlock = 'latest'
+
+  let fromAddresses: string[] = []
+  const logs = await provider.getLogs(filter)
+  for (let i = 0; i < logs.length; i++) {
+    const log = logs[i]
+    console.log(contract.interface.parseLog(log).args)
+    const from = contract.interface.parseLog(log).args.to
+    fromAddresses.push(from)
+  }
+  return fromAddresses
+}
+
+const EVENTS = {
+  FlashOpened: [null, null, null],
+  FlashClosed: [null, null, null],
+  WroteOption: [null, null],
+  Transfer: [null, null, null],
+}
+
+const getAllFromAddresses = async (provider): Promise<any> => {
+  const signer = await provider.getSigner()
+  const connector = await getConnector(signer)
+  let fromAddresses: string[] = []
+  const eventKeys = Object.keys(EVENTS)
+  for (let i = 0; i < eventKeys.length; i++) {
+    // get the from addresses for the event
+    let key = eventKeys[i]
+    let args = EVENTS[key]
+    let addresses = await getAddressFromEvent(provider, connector, key, args)
+    fromAddresses.push(addresses)
+  }
+
+  console.log(fromAddresses)
+  return fromAddresses
+}
+
+const LeaderboardTable: React.FC = () => {
+  const { chainId, active, account, library } = useActiveWeb3React()
+  const [id, storeId] = useState(chainId)
+  const [changing, setChanging] = useState(false)
+  const router = useRouter()
+  useEffect(() => {
+    const { ethereum, web3 } = window as any
+
+    if (MetaMaskOnboarding.isMetaMaskInstalled() && (!ethereum || !web3)) {
+      router.reload()
+    }
+    if (ethereum) {
+      const handleChainChanged = () => {
+        if (id !== chainId) {
+          setChanging(true)
+          storeId(chainId)
+          // eat errors
+          router.reload()
+        }
+      }
+      const handleAccountChanged = () => {
+        router.reload()
+      }
+      if (ethereum?.on) {
+        ethereum?.on('chainChanged', handleChainChanged)
+        ethereum?.on('accountsChanged', handleAccountChanged)
+      }
+      return () => {
+        if (ethereum?.removeListener) {
+          ethereum.removeListener('chainChanged', handleChainChanged)
+          ethereum.removeListener('accountsChanged', handleAccountChanged)
+        }
+      }
+    }
+  }, [id, chainId, storeId])
+
+  const handleOnClick = useCallback(async () => {
+    if (library) {
+      let fromAddresses = await getAllFromAddresses(library)
+    }
+  }, [library, getAllFromAddresses])
+  return (
+    <StyledFAQ>
+      <Spacer />
+      <Spacer />
+      <StyledTitle>Leaderboard {account}</StyledTitle>
+      <Spacer />
+      <Button text="Get Addresses" onClick={handleOnClick} />
+      <Spacer />
+      <StyledTableBody>
+        <Spacer size="sm" />
+        {SPECIFICATIONS.map((specification, i) => {
+          return (
+            <>
+              <TableRow key={i} isHead align="top" height={84}>
+                <TableCell>
+                  <StyledName>{specification.name}</StyledName>
+                </TableCell>
+                <Spacer />
+                <TableCell>
+                  <StyledSub>{specification.score}</StyledSub>
+                </TableCell>
+              </TableRow>
+              <StyledDivLight />
+              <Spacer size="sm" />
+            </>
+          )
+        })}
+      </StyledTableBody>
+      <Spacer />
+      <Spacer />
+    </StyledFAQ>
+  )
+}
+
+const StyledDiv = styled.div`
+  border: 1px solid ${(props) => props.theme.color.grey[600]};
+`
+
+const StyledDivLight = styled.div`
+  border: 1px solid ${(props) => props.theme.color.grey[800]};
+`
+
+const StyledTableBody = styled(TableBody)`
+  width: 100%;
+`
+const StyledSub = styled.span`
+  color: white;
+  opacity: 0.66;
+`
+const StyledName = styled.span`
+  color: white;
+  font-weight: bold;
+`
+const StyledTitle = styled.div`
+  color: white;
+  font-weight: bold;
+  font-size: 36px;
+  width: 100%;
+`
+const StyledFAQ = styled.div`
+  align-items: left;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - ${(props) => props.theme.barHeight * 2}px);
+  max-width: 1000px;
+  margin: 0 2em 0 2em;
+`
+export default LeaderboardTable

--- a/src/components/Market/OrderCard/components/Swap/Swap.tsx
+++ b/src/components/Market/OrderCard/components/Swap/Swap.tsx
@@ -70,13 +70,49 @@ const Swap: React.FC = () => {
   // approval state
   const { item, orderType, loading, approved } = useItem()
 
-  const [prem, setPrem] = useState(
-    orderType === Operation.LONG
-      ? formatEther(item.market.spotOpenPremium.raw.toString())
-      : orderType === Operation.CLOSE_LONG || orderType === Operation.SHORT
-      ? formatEther(item.market.spotClosePremium.raw.toString())
-      : formatEther(item.market.spotUnderlyingToShort.raw.toString())
-  )
+  // slippage
+  const slippage = useSlippage()
+  // pair and option entities
+  const entity = item.entity
+  // multiply by quote divide by base, scale to quote units
+  const scaleUp = (amount) => {
+    return BigNumber.from(amount.toString())
+      .mul(entity.quoteValue.raw.toString())
+      .div(entity.baseValue.raw.toString())
+  }
+
+  // multiply by base divide by quote, scale to base units
+  const scaleDown = (amount) => {
+    return BigNumber.from(amount.toString())
+      .mul(entity.baseValue.raw.toString())
+      .div(entity.quoteValue.raw.toString())
+  }
+
+  const getSpotPremiums = useCallback(() => {
+    return orderType === Operation.LONG
+      ? formatEther(
+          entity.isPut
+            ? scaleDown(item.market.spotOpenPremium.raw.toString())
+            : item.market.spotOpenPremium.raw.toString()
+        )
+      : orderType === Operation.CLOSE_LONG
+      ? formatEther(
+          entity.isPut
+            ? scaleUp(item.market.spotClosePremium.raw.toString())
+            : item.market.spotClosePremium.raw.toString()
+        )
+      : formatEther(
+          entity.isPut
+            ? item.market.spotUnderlyingToShort.raw.toString()
+            : scaleUp(item.market.spotUnderlyingToShort.raw.toString())
+        )
+  }, [orderType, entity.isPut, item.market, scaleUp, scaleDown])
+
+  const [prem, setPrem] = useState(getSpotPremiums())
+
+  useEffect(() => {
+    setPrem(getSpotPremiums())
+  }, [orderType])
 
   const [impact, setImpact] = useState('0.00')
   const [error, setError] = useState(false)
@@ -97,10 +133,6 @@ const Swap: React.FC = () => {
     short: '0',
   })
 
-  // slippage
-  const slippage = useSlippage()
-  // pair and option entities
-  const entity = item.entity
   // has liquidity?
   useEffect(() => {
     if (item.market) {
@@ -275,11 +307,9 @@ const Swap: React.FC = () => {
     // If the order type is close short, the short tokens will be scaled.
     // If the option is a put, scale the inputs up.
     const orderSize = entity.isPut
-      ? orderType === Operation.CLOSE_SHORT
+      ? orderType === Operation.CLOSE_SHORT || orderType === Operation.SHORT
         ? parsedAmount
-        : parsedAmount
-            .mul(entity.baseValue.raw.toString())
-            .div(entity.quoteValue.raw.toString())
+        : scaleDown(parsedAmount)
       : parsedAmount
     submitOrder(library, BigInt(orderSize), orderType, BigInt('0'))
   }, [submitOrder, item, library, parsedAmount, orderType, entity.isPut])
@@ -292,11 +322,7 @@ const Swap: React.FC = () => {
       let debit = '0'
       let credit = '0'
       let short = '0'
-      const size = entity.isPut
-        ? parsedAmount
-            .mul(entity.baseValue.raw.toString())
-            .div(entity.quoteValue.raw.toString())
-        : parsedAmount
+      const size = entity.isPut ? scaleDown(parsedAmount) : parsedAmount
       let actualPremium: TokenAmount
       let spot: TokenAmount
       let slip
@@ -328,6 +354,10 @@ const Swap: React.FC = () => {
           // buy short swap from UNDER -> RDM
         } else if (orderType === Operation.SHORT) {
           if (parsedAmount.gt(BigNumber.from(0))) {
+            ;[spot, actualPremium, slip] = item.market.getExecutionPrice(
+              orderType,
+              entity.isPut ? parsedAmount : scaleUp(parsedAmount)
+            )
             short = formatEther(actualPremium.raw.toString())
           } else {
             setImpact('0.00')
@@ -391,7 +421,7 @@ const Swap: React.FC = () => {
     // else, options are being written, so show the premium paid per option written
     return orderType === Operation.LONG
       ? long
-      : orderType === Operation.CLOSE_SHORT
+      : orderType === Operation.CLOSE_SHORT || orderType === Operation.SHORT
       ? short
       : credit
   }, [item, parsedAmount, cost, orderType, entity.isPut])
@@ -444,13 +474,11 @@ const Swap: React.FC = () => {
         return !totalCost.gt(parseEther(underlyingBalance))
       } else if (orderType === Operation.SHORT) {
         // the amount of options requesting to be written
-        return !totalCost.gt(parseEther(underlyingBalance))
+        return !parseEther(cost.short).gt(parseEther(underlyingBalance))
       } else if (orderType === Operation.CLOSE_LONG) {
         // the order size when closing long options
         const totalLongSold = entity.isPut
-          ? parsedAmount
-              .mul(entity.baseValue.raw.toString())
-              .div(entity.quoteValue.raw.toString())
+          ? scaleDown(parsedAmount)
           : parsedAmount
         // if the close size is greater than the amount of long options held in the wallet
         return !totalLongSold.gt(parseEther(tokenBalance))
@@ -458,16 +486,23 @@ const Swap: React.FC = () => {
         // the close size of closing short tokens
         const totalShortSold = entity.isPut
           ? parsedAmount
-          : parsedAmount
-              .mul(entity.baseValue.raw.toString())
-              .div(entity.quoteValue.raw.toString())
+          : scaleDown(parsedAmount)
         // if the close size exceeds the wallet balance of short option tokens
         return !totalShortSold.gt(parseEther(redeemBalance))
       }
     } else {
       return true
     }
-  }, [entity, parsedAmount, underlyingBalance, tokenBalance, orderType])
+  }, [
+    entity,
+    parsedAmount,
+    underlyingBalance,
+    tokenBalance,
+    orderType,
+    cost,
+    scaleDown,
+    scaleUp,
+  ])
 
   return (
     <>
@@ -639,12 +674,25 @@ const Swap: React.FC = () => {
                 <>
                   {approved[0] ? (
                     <Button
-                      disabled={!parsedAmount?.gt(0) || error || !hasLiquidity}
+                      disabled={
+                        !approved[0] ||
+                        !parsedAmount?.gt(0) ||
+                        error ||
+                        !hasLiquidity ||
+                        !isBelowSlippage() ||
+                        !getHasEnoughForTrade()
+                      }
                       full
                       size="sm"
                       onClick={handleSubmitClick}
                       isLoading={loading}
-                      text="Confirm Trade"
+                      text={
+                        !isBelowSlippage() && typedValue !== ''
+                          ? 'Price Impact Too High'
+                          : getHasEnoughForTrade()
+                          ? 'Confirm Trade'
+                          : 'Insufficient Balance'
+                      }
                     />
                   ) : (
                     <>

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -109,7 +109,7 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
           for{' '}
           <StyledData>
             {' '}
-            {formatParsedAmount(debit.raw.toString())} {short.token.symbol}
+            {formatParsedAmount(short.raw.toString())} {short.token.symbol}
           </StyledData>{' '}
           which gives you the right to withdraw{' '}
           <StyledData>

--- a/src/components/OptionTextInfo/OptionTextInfo.tsx
+++ b/src/components/OptionTextInfo/OptionTextInfo.tsx
@@ -109,19 +109,26 @@ const OptionTextInfo: React.FC<OptionTextInfoProps> = ({
           for{' '}
           <StyledData>
             {' '}
-            {formatParsedAmount(short.raw.toString())} {short.token.symbol}
+            {formatParsedAmount(debit.raw.toString())} {short.token.symbol}
           </StyledData>{' '}
           which gives you the right to withdraw{' '}
           <StyledData>
-            {formatParsedAmount(
-              parsedAmount.mul(strike.raw.toString()).div(parseEther('1'))
-            )}{' '}
+            {isPut
+              ? formatParsedAmount(
+                  parsedAmount.mul(strike.raw.toString()).div(parseEther('1'))
+                )
+              : formatParsedAmount(parsedAmount)}{' '}
             {underlying.token.symbol}
           </StyledData>{' '}
           when the options expire unexercised, or the right to redeem them for{' '}
           <StyledData>
             {' '}
-            {formatParsedAmount(parsedAmount)} {strike.token.symbol}
+            {formatParsedAmount(
+              parsedAmount
+                .mul(strike.raw.toString())
+                .div(underlying.raw.toString())
+            )}{' '}
+            {strike.token.symbol}
           </StyledData>{' '}
           if they are exercised.{' '}
         </>

--- a/src/pages/leaderboard/index.tsx
+++ b/src/pages/leaderboard/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import Spacer from '@/components/Spacer'
+import Title from '@/components/Title'
+import LeaderboardTable from '@/components/LeaderboardTable'
+
+const ADDRESSES = ['0x152Ac2bC1821C5C9ecA56D1F35D8b0D8b61187F5']
+
+const LeaderBoard: React.FC = () => {
+  return (
+    <>
+      <Title>Leaderboard</Title>
+      <Spacer />
+      <LeaderboardTable />
+    </>
+  )
+}
+
+export default LeaderBoard


### PR DESCRIPTION
- Adds new `scaleUp` and `scaleDown` fns. ScaleUp converts the units to QUOTE tokens, by multiplying by quote / base. ScaleDown converts the units to BASE tokens, by multiplying base / quote.
- Adds useEffect for updating spot premiums when `orderType` changes.
- Updated useEffect for calculateTotalCost to put the units in SHORT when calculating short premiums.
- Updates `handleSubmitClick` case when order type is SHORT to use the parsed amount, not a scaled amount.
- Updates the button being used when SHORT orderType is active. Was using a button without our price impact/has enough tokens checks.
- Updates hasEnoughForTrade callback to handle short trade types.
- Updates option text component with `short` cost instead of `debit` when orderType is short.